### PR TITLE
feature: Removing intermediate 3rd party artifacts during build

### DIFF
--- a/Common/3dParty/apple/fetch.sh
+++ b/Common/3dParty/apple/fetch.sh
@@ -12,6 +12,29 @@ abort_op()
     exit 1
 }
 
+shallow_checkout_commit()
+{
+    repo_name="$1"
+    repo_url=$2
+    commit=$3
+
+    mkdir -p "$install_dir/$repo_name" || abort_op "Failed to create $repo_name directory."
+    cd "$install_dir/$repo_name"
+    git init || abort_op "Git init failed ($repo_name)"
+    git remote add origin $repo_url || abort_op "Failed to add $repo_name remote"
+    git fetch --depth 1 origin $commit || abort_op "Failed to fetch $commit"
+    git checkout FETCH_HEAD || abort_op "Check-out failed ($repo_name)"
+}
+
+apply_patch()
+{
+    repo_path="$1"
+    patch_path="$2"
+
+    cd "$repo_path"
+    git apply "$patch_path" || abort_op "Failed to apply $patch_path"
+}
+
 if [ $# -lt 1 ]
 then
     echo "Needs 1 arguments: install_dir_path" >&2
@@ -27,32 +50,22 @@ else
 fi
 
 # glm
-git clone https://github.com/g-truc/glm.git "$install_dir/glm" || abort_op "Failed to clone glm repo"
-cd "$install_dir/glm"
-git checkout 33b4a621a697a305bc3a7610d290677b96beb181 || abort_op "Failed to check out 33b4a621a697a305bc3a7610d290677b96beb181"
+shallow_checkout_commit "glm" "https://github.com/g-truc/glm.git" 33b4a621a697a305bc3a7610d290677b96beb181
 
 # mdds
-git clone https://github.com/kohei-us/mdds.git "$install_dir/mdds" || abort_op "Failed to clone mdds repo"
-cd "$install_dir/mdds"
-git checkout 0783158939c6ce4b0b1b89e345ab983ccb0f0ad0 || abort_op "Failed to checkout 0783158939c6ce4b0b1b89e345ab983ccb0f0ad0"
-git apply "$patches_dir/mdds.patch" || abort_op "Failed to apply mdds.patch"
+shallow_checkout_commit "mdds" "https://github.com/kohei-us/mdds.git" 0783158939c6ce4b0b1b89e345ab983ccb0f0ad0
+apply_patch "$install_dir/mdds" "$patches_dir/mdds.patch"
 
 # librevenge
-git clone https://github.com/Distrotech/librevenge.git "$install_dir/librevenge" || abort_op "Failed to clone librevenge repo"
-cd "$install_dir/librevenge"
-git checkout becd044b519ab83893ad6398e3cbb499a7f0aaf4 || abort_op "Failed to check out becd044b519ab83893ad6398e3cbb499a7f0aaf4"
-git apply "$patches_dir/librevenge.patch"
+shallow_checkout_commit "librevenge" "https://github.com/Distrotech/librevenge.git" becd044b519ab83893ad6398e3cbb499a7f0aaf4
+apply_patch "$install_dir/librevenge" "$patches_dir/librevenge.patch"
 
 # libodfgen
-git clone https://github.com/Distrotech/libodfgen.git "$install_dir/libodfgen" || abort_op "Failed to clone libodfgen repo"
-cd "$install_dir/libodfgen"
-git checkout 8ef8c171ebe3c5daebdce80ee422cf7bb96aa3bc || abort_op "Failed to check out 8ef8c171ebe3c5daebdce80ee422cf7bb96aa3bc"
+shallow_checkout_commit "libodfgen" "https://github.com/Distrotech/libodfgen.git" 8ef8c171ebe3c5daebdce80ee422cf7bb96aa3bc
 
 # libetonyek
-git clone https://github.com/LibreOffice/libetonyek.git "$install_dir/libetonyek" || abort_op "Failed to clone libetonyek repo"
-cd "$install_dir/libetonyek"
-git checkout cb396b4a9453a457469b62a740d8fb933c9442c3 || abort_op "Failed to check out cb396b4a9453a457469b62a740d8fb933c9442c3"
-git apply "$patches_dir/libetonyek.patch" || abort_op "Failed to apply libetonyek.patch"
+shallow_checkout_commit "libetonyek" "https://github.com/LibreOffice/libetonyek.git" cb396b4a9453a457469b62a740d8fb933c9442c3
+apply_patch "$install_dir/libetonyek" "$patches_dir/libetonyek.patch"
 
 # fetch.py is called with use_gperf = False, so I won't bother with that now.
 # see Common/3dParty/apple/fetch.py

--- a/Common/3dParty/brotli/nc-fetch.sh
+++ b/Common/3dParty/brotli/nc-fetch.sh
@@ -24,9 +24,12 @@ else
 fi
 
 echo "Fetching Brotli"
-git clone https://github.com/google/brotli.git "$install_dir" \
-    || abort_op "Failed to clone Brotli repo"
+
+mkdir -p "$install_dir" || abort_op "Failed to create brotli directory."
 cd "$install_dir"
-git checkout a47d7475063eb223c87632eed806c0070e70da29 || abort_op "Failed to check out a47d7475063eb223c87632eed806c0070e70da29"
+git init || abort_op "Git init failed (brotli)"
+git remote add origin https://github.com/google/brotli.git || abort_op "Failed to add brotli remote"
+git fetch --depth 1 origin a47d7475063eb223c87632eed806c0070e70da29 || abort_op "Failed to fetch a47d7475063eb223c87632eed806c0070e70da29"
+git checkout FETCH_HEAD || abort_op "Check-out failed (brotli)"
 
 echo "Brotli ready!"

--- a/Common/3dParty/harfbuzz/nc-fetch.sh
+++ b/Common/3dParty/harfbuzz/nc-fetch.sh
@@ -27,10 +27,13 @@ else
 fi
 
 echo "Fetching Harfbuzz"
-git clone https://github.com/harfbuzz/harfbuzz.git "$install_dir" \
-    || abort_op "Failed to clone Harfbuzz repo"
+
+mkdir -p "$install_dir" || abort_op "Failed to create harfbuzz directory."
 cd "$install_dir"
-git checkout 894a1f72ee93a1fd8dc1d9218cb3fd8f048be29a || abort_op "Failed to check out 894a1f72ee93a1fd8dc1d9218cb3fd8f048be29a"
+git init || abort_op "Git init failed (harfbuzz)"
+git remote add origin https://github.com/harfbuzz/harfbuzz.git || abort_op "Failed to add harfbuzz remote"
+git fetch --depth 1 origin 894a1f72ee93a1fd8dc1d9218cb3fd8f048be29a || abort_op "Failed to fetch 894a1f72ee93a1fd8dc1d9218cb3fd8f048be29a"
+git checkout FETCH_HEAD || abort_op "Check-out failed (harfbuzz)"
 git apply $patches_dir/harfbuzz.patch || abort_op "Failed to apply harfbuzz.patch"
 
 echo "Harfbuzz ready!"

--- a/Common/3dParty/html/nc-fetch.sh
+++ b/Common/3dParty/html/nc-fetch.sh
@@ -14,6 +14,30 @@ abort_op()
     exit 1
 }
 
+shallow_checkout_commit()
+{
+    repo_name="$1"
+    repo_install_dir="$2"
+    repo_url=$3
+    commit=$4
+
+    mkdir -p "$repo_install_dir" || abort_op "Failed to create $repo_name directory."
+    cd "$repo_install_dir"
+    git init || abort_op "Git init failed ($repo_name)"
+    git remote add origin $repo_url || abort_op "Failed to add $repo_name remote"
+    git fetch --depth 1 origin $commit || abort_op "Failed to fetch $commit"
+    git checkout FETCH_HEAD || abort_op "Check-out failed ($repo_name)"
+}
+
+apply_patch()
+{
+    repo_path="$1"
+    patch_path="$2"
+
+    cd "$repo_path"
+    git apply "$patch_path" || abort_op "Failed to apply $patch_path"
+}
+
 if [ $# -lt 2 ]
 then
     echo "Needs 2 arguments: katana_install_dir_path gumbo_install_dir_path" >&2
@@ -38,19 +62,12 @@ fi
 
 
 echo "Fetching Katana parser"
-git clone https://github.com/jasenhuang/katana-parser.git "$install_dir_katana" \
-    || abort_op "Failed to clone Katana repo"
-
-cd "$install_dir_katana"
-git checkout be6df458d4540eee375c513958dcb862a391cdd1 || abort_op "Failed to check out be6df458d4540eee375c513958dcb862a391cdd1"
-git apply $patches_dir/katana.patch || abort_op "Failed to apply katana.patch"
+shallow_checkout_commit "katana-parser" "$install_dir_katana" "https://github.com/jasenhuang/katana-parser.git" be6df458d4540eee375c513958dcb862a391cdd1
+apply_patch "$install_dir_katana" "$patches_dir/katana.patch"
 echo "Katana ready!"
 
 echo "Fetching Gumbo parser"
-git clone https://github.com/google/gumbo-parser.git "$install_dir_gumbo" \
-    || abort_op "Failed to clone Gumbo repo"
-cd "$install_dir_gumbo"
-git checkout aa91b27b02c0c80c482e24348a457ed7c3c088e0 || abort_op "Failed to check out aa91b27b02c0c80c482e24348a457ed7c3c088e0"
-git apply $patches_dir/gumbo.patch || abort_op "Failed to apply gumbo.patch"
+shallow_checkout_commit "gumbo-parser" "$install_dir_gumbo" "https://github.com/google/gumbo-parser.git" aa91b27b02c0c80c482e24348a457ed7c3c088e0
+apply_patch "$install_dir_gumbo" "$patches_dir/gumbo.patch"
 
 echo "Gumbo ready!"

--- a/Common/3dParty/icu/nc-build.sh
+++ b/Common/3dParty/icu/nc-build.sh
@@ -59,6 +59,7 @@ LDFLAGS='-Wl,-rpath,$$ORIGIN' \
 
 make -j10 && make install || abort_op "Build failed"
 
-echo "ICU ready!"
+echo "ICU ready! (work dir will be removed)"
+rm -rf "$work_dir"
 
 exit 0

--- a/Common/3dParty/openssl/nc-build.sh
+++ b/Common/3dParty/openssl/nc-build.sh
@@ -45,6 +45,7 @@ make -j10 || abort_op "Build failed!"
 echo "Installing OpenSSL to: [$install_dir]"
 make install || abort_op "Install failed!"
 
-echo "OpenSSL ready!"
+echo "OpenSSL ready! (work dir will be removed)"
+rm -rf "$work_dir"
 
 exit 0

--- a/Common/3dParty/socketio/nc-fetch.sh
+++ b/Common/3dParty/socketio/nc-fetch.sh
@@ -27,11 +27,18 @@ else
 fi
 
 echo "Fetching Socket-IO"
-git clone https://github.com/socketio/socket.io-client-cpp.git "$install_dir" \
-    || abort_op "Git clone failed!"
-
+mkdir -p "$install_dir" || abort_op "Failed to create Socket-IO directory."
 cd "$install_dir"
-git checkout da779141a7379cc30c870d48295033bc16a23c66 || abort_op "Failed to checkout da779141a7379cc30c870d48295033bc16a23c66"
+git init || abort_op "Git init failed (Socket-IO)"
+git remote add origin https://github.com/socketio/socket.io-client-cpp.git || abort_op "Failed to add Socket-IO remote"
+git fetch --depth 1 origin da779141a7379cc30c870d48295033bc16a23c66 || abort_op "Failed to fetch da779141a7379cc30c870d48295033bc16a23c66"
+git checkout FETCH_HEAD || abort_op "Check-out failed (Socket-IO)"
+
+# git clone https://github.com/socketio/socket.io-client-cpp.git "$install_dir" \
+#     || abort_op "Git clone failed!"
+
+# cd "$install_dir"
+# git checkout da779141a7379cc30c870d48295033bc16a23c66 || abort_op "Failed to checkout da779141a7379cc30c870d48295033bc16a23c66"
 git submodule update --init --recursive || abort_op "Failed to update submodules"
 
 echo "Patching socket-io submodules"

--- a/Common/3dParty/v8/nc-build.sh
+++ b/Common/3dParty/v8/nc-build.sh
@@ -86,4 +86,5 @@ do
     cp "$work_dir/v8/src/base/$f" "$install_dir/v8/src/base/$f" || abort_op "Failed to install ($f)"
 done
 
-echo "v8 ready!"
+echo "v8 ready! (work dir will be removed)"
+rm -rf "$work_dir"


### PR DESCRIPTION
This basically removes the "work dir" of the 3rd party projects after they're built. This saves us a lot of space.
I also made sure that every git repo is shallow cloned.