### PR TITLE
ci: Split build and build-wasm to only run if relevant

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,44 @@
+name: Build WASM
+
+on:
+  pull_request:
+    paths:
+      - '**/wasm/**'
+      - 'DesktopEditor/graphics/pro/js/**'
+      - 'DesktopEditor/fontengine/js/**'
+      - 'DesktopEditor/doctrenderer/**'
+      - 'OfficeUtils/js/**'
+      - '**/CMakeLists.txt'
+      - '**/*.cmake'
+      - '.github/workflows/build-wasm.yml'
+
+jobs:
+  build-wasm:
+    runs-on: [ubuntu-latest, self-hosted]
+    container:
+        image: emscripten/emsdk:latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          path: core/
+
+      - name: Checkout sdkjs repository
+        uses: actions/checkout@v6
+        with:
+          repository: euro-office/sdkjs
+          ref: fork
+          path: sdkjs/
+          token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}
+
+      - name: Verify Emscripten
+        run: emcc -v
+
+      - name: Build with Emscripten
+        run: |
+          mkdir -p ../build-wasm-dir
+          cd ../build-wasm-dir
+          /bin/bash -c "emcmake cmake -S $GITHUB_WORKSPACE/core -B . -DEO_CORE_OUTPUT_DIR=$GITHUB_WORKSPACE/package && cmake --build ."
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  push:
   pull_request:
 
 jobs:
@@ -41,34 +40,3 @@ jobs:
     
     - name: Build
       run: cmake --build build
-
-# 2. WebAssembly Build
-  build-wasm:
-    runs-on: [ubuntu-latest, self-hosted]
-    container:
-        image: emscripten/emsdk:latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-          path: core/
-
-      - name: Checkout sdkjs repository
-        uses: actions/checkout@v6
-        with:
-          repository: euro-office/sdkjs
-          ref: fork
-          path: sdkjs/
-          token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}
-
-      - name: Verify Emscripten
-        run: emcc -v
-
-      - name: Build with Emscripten
-        run: |
-          mkdir -p ../build-wasm-dir
-          cd ../build-wasm-dir
-          /bin/bash -c "emcmake cmake -S $GITHUB_WORKSPACE/core -B . -DEO_CORE_OUTPUT_DIR=$GITHUB_WORKSPACE/package && cmake --build ."
-        shell: bash


### PR DESCRIPTION
We likely only need to build wasm if related files change, so this will save some CI time.