### PR TITLE
fix: Require boost regex and link static libstdc++ and libgcc

### DIFF
--- a/X2tConverter/build/cmake/CMakeLists.txt
+++ b/X2tConverter/build/cmake/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CORE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 
 include(${CORE_ROOT_DIR}/common.cmake)
 
+find_package(Boost REQUIRED COMPONENTS regex)
+
 set(X2T_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 add_subdirectory(library)
@@ -19,6 +21,7 @@ set_default_options(x2t)
 # dynamic libs
 target_link_libraries(x2t PRIVATE
     x2tlib
+    Boost::regex
 )
 
 copy_artifacts_to_folder("x2t" "${EO_CORE_OUTPUT_DIR}")

--- a/common.cmake
+++ b/common.cmake
@@ -1,5 +1,10 @@
 include_guard(GLOBAL)
 
+# CMake 3.25+ sets LINUX automatically; older versions (Ubuntu 22.04 ships 3.22) do not.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT DEFINED LINUX)
+    set(LINUX TRUE)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -82,6 +87,13 @@ set(COMMON_C_FLAGS
 
 set(COMMON_LINK_OPTIONS
     "-Wl,--disable-new-dtags"
+    # Statically bundle the C++ runtime and GCC support library into each
+    # binary/shared-library so the GLIBCXX version on the target system is
+    # irrelevant.  Note: glibc itself cannot be statically linked into .so
+    # files, so the build image must still target a suitably old glibc
+    # (see Dockerfile core stage).
+    -static-libstdc++
+    -static-libgcc
 )
 
 


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>
