### PR TITLE
fix(license): rebrand copyright headers from Ascensio to Euro-Office contributors

### DIFF
--- a/Common/license/header.license
+++ b/Common/license/header.license
@@ -1,11 +1,11 @@
 /*
- * (c) Copyright Ascensio System SIA 2010-2023
+ * (c) Copyright Euro-Office contributors 2010-2026
  *
  * This program is a free software product. You can redistribute it and/or
  * modify it under the terms of the GNU Affero General Public License (AGPL)
  * version 3 as published by the Free Software Foundation. In accordance with
  * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
- * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * that Euro-Office contributors expressly exclude the warranty of non-infringement
  * of any third-party rights.
  *
  * This program is distributed WITHOUT ANY WARRANTY; without even the implied


### PR DESCRIPTION
## Summary

Rebrand copyright headers in core/Common/license/header.license from Ascensio System SIA to Euro-Office contributors.