### PR TITLE
Add missing third-party dependency entries to 3DPARTY

### DIFF
--- a/3DPARTY.md
+++ b/3DPARTY.md
@@ -16,3 +16,7 @@
 - cryptopp ([BSL](https://raw.githubusercontent.com/weidai11/cryptopp/master/License.txt))
 - openssl ([Apache-2.0](https://raw.githubusercontent.com/openssl/openssl/master/LICENSE.txt))
 - v8 ([3-clause BSD License](https://raw.githubusercontent.com/v8/v8/main/LICENSE))
+- POLE ([BSD-3-Clause](https://raw.githubusercontent.com/ArtifexSoftware/pole/master/LICENSE))
+- SocketRocket ([Apache-2.0](https://raw.githubusercontent.com/Flipboard/SocketRocket/master/LICENSE))
+- IXWebSocket ([BSD-3-Clause](https://raw.githubusercontent.com/machinezone/IXWebSocket/master/LICENSE))
+- GLEW ([BSD/MIT](https://raw.githubusercontent.com/nigels-com/glew/master/LICENSE.txt))


### PR DESCRIPTION
## Summary
- Added POLE (BSD-3-Clause), OLE storage parser
- Added SocketRocket (Apache-2.0), iOS WebSocket library
- Added IXWebSocket (BSD-3-Clause), C++ WebSocket library
- Added GLEW (BSD/MIT), OpenGL Extension Wrangler

## Details
These four third-party libraries were present in `Common/3dParty/` but missing from `3DPARTY.md`. License information was determined from source file headers (POLE) and upstream repository defaults (SocketRocket, IXWebSocket, GLEW).