### PR TITLE
fix: suppress Python 3.12 SyntaxWarning in gn gen.py

### DIFF
--- a/Common/3dParty/v8/nc-build.sh
+++ b/Common/3dParty/v8/nc-build.sh
@@ -253,6 +253,9 @@ while IFS= read -r commit; do
   fi
 done < <(git log --format="%H" --before="2022-01-01")
 
+# Fix Python 3.12+ SyntaxWarning: invalid escape sequence '\d' in gen.py
+sed -i "s/ROOT_TAG + '-/ROOT_TAG + r'-/g" build/gen.py
+
 CC=clang-13 CXX=clang++-13 python3 build/gen.py --no-last-commit-position
 
 # Der Compiler sucht last_commit_position.h via -I. (= out/ Verzeichnis)


### PR DESCRIPTION
Python 3.12 (shipped with Ubuntu 24.04) raises a SyntaxWarning for invalid escape sequences in plain strings. The gn-source gen.py uses '\d' in a regex string literal, triggering this warning at build time.

Since the gn commit is selected dynamically, a static patch file cannot be applied reliably. Instead, a targeted sed substitution is applied after checkout to prefix the affected string literal with r'', making it a raw string and silencing the warning.