### PR TITLE
Fix: docker warnings + first step towards arm64

### DIFF
--- a/.docker/core.bake.Dockerfile
+++ b/.docker/core.bake.Dockerfile
@@ -122,14 +122,16 @@ FROM vcpkg-${NUGET_CACHE} AS core-base
 #### CORE ####
 FROM core-base AS core
     ARG NUGET_SOURCE_PATH
+    ARG TARGETARCH
     RUN --mount=type=cache,target=/build-cache \
         --mount=type=bind,source=${NUGET_SOURCE_PATH},target=/nuget-cache,rw \
+        VCPKG_TRIPLET=$([ "$TARGETARCH" = "arm64" ] && echo "arm64-linux-dynamic" || echo "x64-linux-dynamic") && \
         mkdir -p ${BUILD_ROOT} && \
         cd /build-cache && \
         cmake -GNinja \
         -DVCPKG_MANIFEST_MODE=ON \
         -DVCPKG_MANIFEST_DIR=/core \
-        -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic \
+        -DVCPKG_TARGET_TRIPLET=${VCPKG_TRIPLET} \
         -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_CXX_FLAGS_RELEASE="-O3 -w" \


### PR DESCRIPTION
Hardcoded x64-linux-dynamic caused vcpkg's compiler detection to fail
when building on arm64 (e.g. Apple Silicon), as vcpkg would attempt to
cross-compile to x64 without a cross-compiler available.

The triplet is now derived from TARGETARCH, resolving to
arm64-linux-dynamic on arm64 and x64-linux-dynamic on amd64.

This is a first step towards building arm64-linux-dynamic binaries.

The custom overlay ports (boost, cef, qt, v8) don't build from source,
they download pre-built binaries from  Nextcloud (cloud.nextcloud.com/..).
Those binaries only exist for x64-linux-dynamic. No arm64-linux-dynamic binaries are available yet.