### PR TITLE
fix(ci): remove token requirement for public sdkjs checkout

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -28,10 +28,9 @@ jobs:
       - name: Checkout sdkjs repository
         uses: actions/checkout@v6
         with:
-          repository: euro-office/sdkjs
+          repository: Euro-Office/sdkjs
           ref: main
           path: sdkjs/
-          token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}
 
       - name: Verify Emscripten
         run: emcc -v


### PR DESCRIPTION
## Summary

- Removes the `token: ${{ secrets.EURO_OFFICE_MIRROR_TOKEN }}` from the sdkjs checkout step in `build-wasm.yml`
- Fixes repository name casing: `euro-office/sdkjs` → `Euro-Office/sdkjs`

## Problem

All WASM builds were failing with:
```
##[error]Input required and not supplied: token
```

The `EURO_OFFICE_MIRROR_TOKEN` secret was never configured in the repository settings. Since `Euro-Office/sdkjs` is a **public** repository, the default `GITHUB_TOKEN` provided by GitHub Actions is sufficient for checkout — no custom token is needed.

## Testing

- Verified `Euro-Office/sdkjs` is public: `gh repo view Euro-Office/sdkjs` → `visibility: PUBLIC`
- The `actions/checkout@v6` action uses `GITHUB_TOKEN` by default when no `token` is specified, which works for public repos