### PR TITLE
feat: lift emsdk version to 5.0.4 for arm support

### DIFF
--- a/.docker/core-wasm.bake.Dockerfile
+++ b/.docker/core-wasm.bake.Dockerfile
@@ -8,7 +8,7 @@
 # ==============================================================================
 
 #### CORE WASM ####
-FROM emscripten/emsdk:3.1.48 AS core-wasm 
+FROM emscripten/emsdk:5.0.4 AS core-wasm 
     ARG BUILD_ROOT
     ARG CACHE_BUST
     ARG NUGET_SOURCE_PATH


### PR DESCRIPTION
This PR lifts emsdk to 5.0.4 so that we have a arm docker image