### PR TITLE
fix(docker): install cmake 4.x from Kitware apt repo in core-base

### DIFF
--- a/.docker/core.bake.Dockerfile
+++ b/.docker/core.bake.Dockerfile
@@ -76,16 +76,25 @@ FROM vcpkg-${NUGET_CACHE} AS core-base
     ENV DEBIAN_FRONTEND=noninteractive
     ENV PLEASE_PRELOAD_LIBSTDCPP=true
 
+    # cmake from ubuntu noble is 3.28.x; vcpkg now requires >=4.x.
+    # Install cmake 4.x from Kitware's apt repo here (after vcpkg bootstrap)
+    # so the vcpkg-base git-clone+bootstrap layer remains cacheable even when
+    # GitHub CDN is unreachable in network-restricted build environments.
     RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
         apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            git curl sudo wget ssh \
-            build-essential make cmake ninja-build pkg-config \
+            git curl sudo wget ssh gpg \
+            build-essential make ninja-build pkg-config \
             libglib2.0-dev \
             python3 python-is-python3 python3-venv python3-setuptools \
             python3-httplib2 \
             lsb-release libboost-all-dev findutils \
             gn \
+        && curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc \
+            | gpg --dearmor -o /etc/apt/keyrings/kitware.gpg \
+        && echo "deb [signed-by=/etc/apt/keyrings/kitware.gpg] https://apt.kitware.com/ubuntu/ noble main" \
+            > /etc/apt/sources.list.d/kitware.list \
+        && apt-get update && apt-get install -y cmake \
         && rm -rf /var/lib/apt/lists/*
 
     # clang-13 required for V8 9.x — only available on jammy (22.04), not noble (24.04)


### PR DESCRIPTION
vcpkg now requires cmake >=4.2.3, but ubuntu:24.04 only ships 3.28.x. In network-restricted build environments, vcpkg falls back to downloading cmake 4.x from GitHub CDN (github.com/Kitware/CMake/releases), which fails when CDN access is blocked.

Install cmake 4.x from Kitware's apt repo (apt.kitware.com/ubuntu noble) in the core-base stage — after vcpkg is already bootstrapped and cached — so vcpkg finds a suitable cmake at configure time and never attempts a GitHub CDN download.

The cmake upgrade is intentionally placed in core-base, not vcpkg-base, to avoid invalidating the vcpkg git-clone+bootstrap layer cache. That bootstrap step itself downloads a prebuilt binary from GitHub CDN and must remain warm in the cache for restricted-network builds.

Also remove the duplicate cmake install from core-base since it is now provided by Kitware.