### PR TITLE
feat: build core with ubuntu22 for compatibility for older distros

### DIFF
--- a/.docker/core.bake.Dockerfile
+++ b/.docker/core.bake.Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_ROOT
 ARG NUGET_SOURCE_PATH
 
 #### VCPKG BASE ####
-FROM ubuntu:24.04 AS vcpkg-base
+FROM ubuntu:22.04 AS vcpkg-base
 
     # Avoid interactive prompts during package install
     ENV DEBIAN_FRONTEND=noninteractive
@@ -68,13 +68,20 @@ FROM vcpkg-base AS vcpkg-remote
 
 
 #### CORE BASE ####
+# Build on Ubuntu 22.04 (Jammy, glibc 2.35) so the output binaries never
+# reference glibc symbols newer than 2.35.  This covers Debian 12 (glibc 2.36)
+# and Rocky Linux 9 (glibc 2.34 — glibc 2.35 symbols are avoided in practice
+# as the code does not call any functions first introduced in 2.35).
+# libstdc++ and libgcc are statically linked via -static-libstdc++ -static-libgcc
+# (see common.cmake) so the GLIBCXX version on the target system is irrelevant.
+# glibc itself cannot be statically linked into shared libraries, hence the
+# old Ubuntu base remains necessary.
 FROM vcpkg-${NUGET_CACHE} AS core-base
     ARG BUILD_ROOT=/package
     ARG TARGETARCH
 
     ENV TZ=Etc/UTC
     ENV DEBIAN_FRONTEND=noninteractive
-    ENV PLEASE_PRELOAD_LIBSTDCPP=true
 
     # cmake from ubuntu noble is 3.28.x; vcpkg now requires >=4.x.
     # Install cmake 4.x from Kitware's apt repo here (after vcpkg bootstrap)
@@ -88,13 +95,13 @@ FROM vcpkg-${NUGET_CACHE} AS core-base
             libglib2.0-dev \
             python3 python-is-python3 python3-venv python3-setuptools \
             python3-httplib2 \
-            lsb-release libboost-all-dev findutils \
+            lsb-release autoconf automake libtool findutils \
             gn \
-        && curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc \
-            | gpg --dearmor -o /etc/apt/keyrings/kitware.gpg \
-        && echo "deb [signed-by=/etc/apt/keyrings/kitware.gpg] https://apt.kitware.com/ubuntu/ noble main" \
-            > /etc/apt/sources.list.d/kitware.list \
-        && apt-get update && apt-get install -y cmake \
+        #&& curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc \
+        #    | gpg --dearmor -o /etc/apt/keyrings/kitware.gpg \
+        #&& echo "deb [signed-by=/etc/apt/keyrings/kitware.gpg] https://apt.kitware.com/ubuntu/ noble main" \
+        #    > /etc/apt/sources.list.d/kitware.list \
+        #&& apt-get update && apt-get install -y cmake \
         && rm -rf /var/lib/apt/lists/*
 
     # clang-13 required for V8 9.x — only available on jammy (22.04), not noble (24.04)

--- a/DesktopEditor/freetype-2.10.4/builds/unix/ftsystem.c
+++ b/DesktopEditor/freetype-2.10.4/builds/unix/ftsystem.c
@@ -24,6 +24,7 @@
 #include <freetype/fterrors.h>
 #include <freetype/fttypes.h>
 #include <freetype/internal/ftstream.h>
+#include <fcntl.h>
 
   /* memory-mapping includes and definitions */
 #ifdef HAVE_UNISTD_H

--- a/DesktopEditor/graphics/cmake/CMakeLists.txt
+++ b/DesktopEditor/graphics/cmake/CMakeLists.txt
@@ -1038,6 +1038,8 @@ target_compile_definitions(graphics PRIVATE
     HAVE_FREETYPE
     HB_NO_VISIBILITY
 
+    _lseek=lseek
+
     # brotli.pri
     FT_CONFIG_OPTION_USE_BROTLI
 )

--- a/X2tConverter/build/cmake/CMakeLists.txt
+++ b/X2tConverter/build/cmake/CMakeLists.txt
@@ -6,6 +6,9 @@ set(CORE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
 
 include(${CORE_ROOT_DIR}/common.cmake)
 
+set(BOOST_ROOT "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/boost/linux_64")
+find_package(Boost REQUIRED COMPONENTS system filesystem regex date_time)
+
 set(X2T_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 add_subdirectory(library)

--- a/common.cmake
+++ b/common.cmake
@@ -138,7 +138,7 @@ endfunction()
 function(copy_icu_libs artifact)
     add_custom_command(TARGET ${artifact} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory "${EO_CORE_OUTPUT_DIR}"
-        COMMAND /bin/sh -c "cp -P --update=none \"${EO_CORE_3RD_PARTY_INSTALL_DIR}/icu/lib\"/*.so* \"${EO_CORE_OUTPUT_DIR}/\""
+        COMMAND /bin/sh -c "cp -P \"${EO_CORE_3RD_PARTY_INSTALL_DIR}/icu/lib\"/*.so* \"${EO_CORE_OUTPUT_DIR}/\""
         COMMENT "Copying ICU libs to ${EO_CORE_OUTPUT_DIR}"
     )
 endfunction()
@@ -146,7 +146,7 @@ endfunction()
 function(copy_boost_libs artifact)
     add_custom_command(TARGET ${artifact} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory "${EO_CORE_OUTPUT_DIR}"
-        COMMAND /bin/sh -c "cp -P --update=none \"${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/boost/linux_64/lib\"/*.so* \"${EO_CORE_OUTPUT_DIR}/\""
+        COMMAND /bin/sh -c "cp -P \"${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/boost/linux_64/lib\"/*.so* \"${EO_CORE_OUTPUT_DIR}/\""
         COMMENT "Copying Boost libs to ${EO_CORE_OUTPUT_DIR}"
     )
 endfunction()


### PR DESCRIPTION
This PR builds core on Ubuntu 22.04 to make it compatible with older distros. This is relevant for package building (https://github.com/Euro-Office/DocumentServer/pull/92).

This is a rework of https://github.com/Euro-Office/DocumentServer/pull/28