### PR TITLE
Fix RTF antiqueWhite preset color

### DIFF
--- a/RtfFile/Format/RtfProperty.cpp
+++ b/RtfFile/Format/RtfProperty.cpp
@@ -525,7 +525,7 @@ bool RtfColor::GetHighlightByColor( RtfColor oOutputColor,std::wstring& oStr ) /
 RtfColor RtfColor::GetColorByPreset( std::wstring oStr )
 {
 	if		( oStr == L"aliceBlue" )	return RtfColor(240,248,255);
-	else if ( oStr == L"aniqueWhite" )	return RtfColor(250,235,215);
+	else if ( oStr == L"antiqueWhite" )	return RtfColor(250,235,215);
 	else if ( oStr == L"aqua" )			return RtfColor(0,255,255);
 	else if ( oStr == L"aquamarine" )	return RtfColor(127,255,212);
 	else if ( oStr == L"azure" )		return RtfColor(240,255,255);
@@ -549,7 +549,7 @@ RtfColor RtfColor::GetColorByPreset( std::wstring oStr )
 std::wstring RtfColor::GetPresetByColor( RtfColor oCol ) //стр. 3320
 {
 	if		( oCol == RtfColor(240,248,255))	return L"aliceBlue";
-	else if ( oCol == RtfColor(250,235,215))	return L"aniqueWhite";
+	else if ( oCol == RtfColor(250,235,215))	return L"antiqueWhite";
 	else if ( oCol == RtfColor(0,255,255))		return L"aqua";
 	else if ( oCol == RtfColor(127,255,212))	return L"aquamarine";
 	else if ( oCol == RtfColor(240,255,255))	return L"azure";


### PR DESCRIPTION
## Summary
- Correct the RTF preset color name from `aniqueWhite` to `antiqueWhite`.
- Keep RTF preset parsing/writing consistent with the OOXML preset color mappings already present in core.

## Why
The RTF color helper used a misspelled preset name for RGB 250,235,215. As a result, valid `antiqueWhite` preset input was not recognized by this mapping, and serializing that color emitted the non-standard `aniqueWhite` name.

## Validation
- Ran `git diff --check`.
- Confirmed `aniqueWhite` no longer appears in the repository.
- Confirmed the RTF mapping now matches the existing OOXML `antiqueWhite` mappings.
