### PR TITLE
Fix RTF shape crop property mapping

### DIFF
--- a/RtfFile/Format/DestinationCommand.cpp
+++ b/RtfFile/Format/DestinationCommand.cpp
@@ -3024,8 +3024,8 @@ void RtfShapeReader::ShapePropertyReader::ShapePropertyValueReader::PopState( Rt
 	//WordArt Effects
 	else if ( L"cropFromTop"	== m_sPropName ) m_oShape.m_nCropFromTop	= nValue;
 	else if ( L"cropFromBottom"	== m_sPropName ) m_oShape.m_nCropFromBottom = nValue;
-	else if ( L"cropFromLeft"	== m_sPropName ) m_oShape.m_nCropFromRight	= nValue;
-	else if ( L"cropFromRight"	== m_sPropName ) m_oShape.m_nCropFromTop	= nValue;
+	else if ( L"cropFromLeft"	== m_sPropName ) m_oShape.m_nCropFromLeft	= nValue;
+	else if ( L"cropFromRight"	== m_sPropName ) m_oShape.m_nCropFromRight	= nValue;
 	//Grouped Shapes
 	else if ( L"groupBottom"	== m_sPropName ) m_oShape.m_nGroupBottom	= nValue;
 	else if ( L"groupLeft"		== m_sPropName ) m_oShape.m_nGroupLeft		= nValue;


### PR DESCRIPTION
## Summary
- Map `cropFromLeft` to `m_nCropFromLeft`.
- Map `cropFromRight` to `m_nCropFromRight`.

## Why
The RTF shape property reader had two copy/paste assignments in the picture crop block:

- `cropFromLeft` was stored in `m_nCropFromRight`.
- `cropFromRight` was stored in `m_nCropFromTop`.

This can make imported RTF picture cropping use the wrong side. The assignments now match the field names, the RTF shape serializer, and the OOXML/MS binary crop readers in this repository.

## Validation
- Ran `git diff --check`.
- Checked `RtfShape` crop field definitions.
- Checked `RtfShape` RTF serialization for the same crop properties.
