### PR TITLE
Fix RTF shape border color mapping

### DIFF
--- a/RtfFile/Format/RtfShape.cpp
+++ b/RtfFile/Format/RtfShape.cpp
@@ -314,7 +314,7 @@ std::wstring RtfShape::RenderToRtf(RenderParameter oRenderParameter)
 				if (m_bLine)
 				{
 					if (m_nBorderTopColor == PROP_DEF)
-						m_nBorderTopColor = m_nBorderLeftColor = m_nBorderTopColor = m_nBorderBottomColor = m_nLineColor;
+						m_nBorderTopColor = m_nBorderLeftColor = m_nBorderRightColor = m_nBorderBottomColor = m_nLineColor;
 
 					INT brdrw = PROP_DEF;
 					if (PROP_DEF != m_nLineWidth)
@@ -527,8 +527,8 @@ std::wstring RtfShape::RenderToRtfShapeProperty(RenderParameter oRenderParameter
 
 	RENDER_RTF_SHAPE_PROP(L"o:bordertopcolor", sResult, m_nBorderTopColor);
 	RENDER_RTF_SHAPE_PROP(L"o:borderleftcolor", sResult, m_nBorderLeftColor);
-	RENDER_RTF_SHAPE_PROP(L"o:borderbottomcolor", sResult, m_nBorderRightColor);
-	RENDER_RTF_SHAPE_PROP(L"o:borderrightcolor", sResult, m_nBorderBottomColor);
+	RENDER_RTF_SHAPE_PROP(L"o:borderbottomcolor", sResult, m_nBorderBottomColor);
+	RENDER_RTF_SHAPE_PROP(L"o:borderrightcolor", sResult, m_nBorderRightColor);
 
 //Position relative
     RENDER_RTF_SHAPE_PROP(L"pctHorizPos",	sResult,	m_nPositionHPct);


### PR DESCRIPTION
## Summary
- Include `m_nBorderRightColor` when copying line color to picture border colors.
- Write `o:borderbottomcolor` from `m_nBorderBottomColor`.
- Write `o:borderrightcolor` from `m_nBorderRightColor`.

## Why
Two RTF shape border color mappings were inconsistent:

- The line-color fallback assigned `m_nBorderTopColor` twice and never assigned `m_nBorderRightColor`.
- Shape property rendering emitted bottom border color from the right field and right border color from the bottom field.

Both cases can make a shape or picture border use the wrong side's color when round-tripping RTF.

## Validation
- Ran `git diff --check`.
- Checked the border color field definitions.
- Checked the RTF shape property reader and VML-style shape rendering for the same border color fields.
