### PR TITLE
feat(xlsx): support Excel cell checkboxes in conversion

### DIFF
--- a/OOXML/Binary/Sheets/Common/BinReaderWriterDefines.h
+++ b/OOXML/Binary/Sheets/Common/BinReaderWriterDefines.h
@@ -137,7 +137,8 @@ namespace BinXlsxRW
 		QuotePrefix = 11,
 		XfId = 12,
 		Aligment = 13,
-		Protection = 14
+		Protection = 14,
+		CellControl = 15
 	};}
 	namespace c_oSerProtectionTypes {enum c_oSerProtectionTypes
 	{

--- a/OOXML/Binary/Sheets/Reader/BinaryWriterS.cpp
+++ b/OOXML/Binary/Sheets/Reader/BinaryWriterS.cpp
@@ -65,6 +65,7 @@
 #include "../../../XlsxFormat/Styles/TableStyles.h"
 #include "../../../XlsxFormat/Timelines/Timeline.h"
 #include "../../../XlsxFormat/Workbook/Metadata.h"
+#include "../../../XlsxFormat/Workbook/FeaturePropertyBag.h"
 #include "../../../XlsxFormat/Table/Table.h"
 #include "../../../XlsxFormat/Workbook/CustomsXml.h"
 #include "../../../XlsxFormat/RichData/RdRichData.h"
@@ -1445,6 +1446,13 @@ void BinaryStyleTableWriter::WriteXfs(const OOX::Spreadsheet::CXfs& xfs)
 		m_oBcw.m_oStream.WriteBYTE(c_oSerXfsTypes::PivotButton);
 		m_oBcw.m_oStream.WriteBYTE(c_oSerPropLenType::Byte);
 		m_oBcw.m_oStream.WriteBOOL(xfs.m_oPivotButton->ToBool());
+	}
+	//CellControl (checkbox)
+	if (false != xfs.m_oCellControl.IsInit())
+	{
+		m_oBcw.m_oStream.WriteBYTE(c_oSerXfsTypes::CellControl);
+		m_oBcw.m_oStream.WriteBYTE(c_oSerPropLenType::Byte);
+		m_oBcw.m_oStream.WriteBOOL(*xfs.m_oCellControl);
 	}
 	//XfId
 	if (false != xfs.m_oXfId.IsInit())
@@ -9336,6 +9344,33 @@ void BinaryFileWriter::WriteContent(OOX::Document *pDocument, NSFontCutter::CEmb
 //Styles
 	if(pStyles)
 	{
+		if (pWorkbook)
+		{
+			//resolve xf checkbox controls via the workbook featurePropertyBag part
+			smart_ptr<OOX::File> pFile = pWorkbook->Find(OOX::Spreadsheet::FileTypes::FeaturePropertyBag);
+			OOX::Spreadsheet::CFeaturePropertyBagFile* pBagFile = dynamic_cast<OOX::Spreadsheet::CFeaturePropertyBagFile*>(pFile.GetPointer());
+			if (pBagFile)
+			{
+				if (pStyles->m_oCellXfs.IsInit())
+				{
+					for (size_t i = 0; i < pStyles->m_oCellXfs->m_arrItems.size(); ++i)
+					{
+						OOX::Spreadsheet::CXfs* pXfs = pStyles->m_oCellXfs->m_arrItems[i];
+						if ((pXfs) && (pXfs->m_oXfComplementIndex.IsInit()))
+							pXfs->m_oCellControl = pBagFile->IsCheckboxComplement(*pXfs->m_oXfComplementIndex);
+					}
+				}
+				if (pStyles->m_oCellStyleXfs.IsInit())
+				{
+					for (size_t i = 0; i < pStyles->m_oCellStyleXfs->m_arrItems.size(); ++i)
+					{
+						OOX::Spreadsheet::CXfs* pXfs = pStyles->m_oCellStyleXfs->m_arrItems[i];
+						if ((pXfs) && (pXfs->m_oXfComplementIndex.IsInit()))
+							pXfs->m_oCellControl = pBagFile->IsCheckboxComplement(*pXfs->m_oXfComplementIndex);
+					}
+				}
+			}
+		}
 		nCurPos = WriteTableStart(c_oSerTableTypes::Styles);
 		BinaryStyleTableWriter oBinaryStyleTableWriter(m_oBcw->m_oStream, pEmbeddedFontsManager);
 		oBinaryStyleTableWriter.Write(*pStyles, pXlsx ? pXlsx->GetTheme() : NULL, m_oFontProcessor);

--- a/OOXML/Binary/Sheets/Writer/BinaryReaderS.cpp
+++ b/OOXML/Binary/Sheets/Writer/BinaryReaderS.cpp
@@ -65,6 +65,7 @@
 #include "../../../XlsxFormat/Controls/Controls.h"
 #include "../../../XlsxFormat/Timelines/Timeline.h"
 #include "../../../XlsxFormat/Workbook/Metadata.h"
+#include "../../../XlsxFormat/Workbook/FeaturePropertyBag.h"
 #include "../../../XlsxFormat/Workbook/CustomsXml.h"
 #include "../../../XlsxFormat/RichData/RdRichData.h"
 
@@ -1971,6 +1972,10 @@ int BinaryStyleTableReader::ReadXfs(BYTE type, long length, void* poResult)
 	{
 		pXfs->m_oXfId.Init();
 		pXfs->m_oXfId->SetValue(m_oBufferedStream.GetLong());
+	}
+	else if (c_oSerXfsTypes::CellControl == type)
+	{
+		pXfs->m_oCellControl = m_oBufferedStream.GetBool();
 	}
 	else
 		res = c_oSerConstants::ReadUnknown;
@@ -9931,6 +9936,38 @@ int BinaryFileReader::ReadMainTable(OOX::Spreadsheet::CXlsx& oXlsx, NSBinPptxRW:
 		}	
 		if (c_oSerConstants::ReadOk != res)
 			return res;
+	}
+	OOX::Spreadsheet::CXlsb* pXlsb = dynamic_cast<OOX::Spreadsheet::CXlsb*>(&oXlsx);
+	if (oXlsx.m_pStyles && oXlsx.m_pWorkbook && (!pXlsb || !pXlsb->m_bWriteToXlsb))
+	{
+		//checkbox xfs reference the canonical featurePropertyBag part - create it on demand
+		bool bHasCellControl = false;
+		if (oXlsx.m_pStyles->m_oCellXfs.IsInit())
+		{
+			for (size_t i = 0; !bHasCellControl && i < oXlsx.m_pStyles->m_oCellXfs->m_arrItems.size(); ++i)
+			{
+				OOX::Spreadsheet::CXfs* pXfs = oXlsx.m_pStyles->m_oCellXfs->m_arrItems[i];
+				if ((pXfs) && (pXfs->m_oCellControl.IsInit()) && (*pXfs->m_oCellControl))
+					bHasCellControl = true;
+			}
+		}
+		if (oXlsx.m_pStyles->m_oCellStyleXfs.IsInit())
+		{
+			for (size_t i = 0; !bHasCellControl && i < oXlsx.m_pStyles->m_oCellStyleXfs->m_arrItems.size(); ++i)
+			{
+				OOX::Spreadsheet::CXfs* pXfs = oXlsx.m_pStyles->m_oCellStyleXfs->m_arrItems[i];
+				if ((pXfs) && (pXfs->m_oCellControl.IsInit()) && (*pXfs->m_oCellControl))
+					bHasCellControl = true;
+			}
+		}
+		if (bHasCellControl)
+		{
+			smart_ptr<OOX::Spreadsheet::CFeaturePropertyBagFile> oBagFile(new OOX::Spreadsheet::CFeaturePropertyBagFile(NULL));
+			oBagFile->OOX::File::m_pMainDocument = oXlsx.m_pWorkbook->OOX::File::m_pMainDocument;
+
+			smart_ptr<OOX::File> oFile = oBagFile.smart_dynamic_cast<OOX::File>();
+			oXlsx.m_pWorkbook->Add(oFile);
+		}
 	}
 	for (boost::unordered_map<long, ImageObject*>::const_iterator pPair = mapMedia.begin(); pPair != mapMedia.end(); ++pPair)
 	{

--- a/OOXML/Projects/Linux/DocxFormatLib/CMakeLists.txt
+++ b/OOXML/Projects/Linux/DocxFormatLib/CMakeLists.txt
@@ -168,6 +168,7 @@ add_library(DocxFormatLib STATIC
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/CustomsXml.cpp
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/DefinedNames.cpp
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/ExternalReferences.cpp
+    ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/FeaturePropertyBag.cpp
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Metadata.cpp
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Sheets.cpp
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Workbook.cpp
@@ -359,6 +360,7 @@ add_library(DocxFormatLib STATIC
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/CustomsXml.h
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/DefinedNames.h
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/ExternalReferences.h
+    ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/FeaturePropertyBag.h
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Metadata.h
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Sheets.h
     ${OOXML_ROOT_DIR}/XlsxFormat/Workbook/Workbook.h

--- a/OOXML/Projects/Linux/DocxFormatLib/DocxFormatLib.pro
+++ b/OOXML/Projects/Linux/DocxFormatLib/DocxFormatLib.pro
@@ -187,6 +187,7 @@ SOURCES += \
 	../../../XlsxFormat/Drawing/Pos.cpp \
 	../../../XlsxFormat/ExternalLinks/ExternalLinkPath.cpp \
 	../../../XlsxFormat/ExternalLinks/ExternalLinks.cpp \
+        ../../../XlsxFormat/Workbook/FeaturePropertyBag.cpp \
         ../../../XlsxFormat/Workbook/Metadata.cpp \
         ../../../XlsxFormat/RichData/RdRichData.cpp \
         ../../../XlsxFormat/Ole/OleObjects.cpp \
@@ -393,6 +394,7 @@ HEADERS += \
 	../../../XlsxFormat/Slicer/SlicerCacheExt.h \
 	../../../XlsxFormat/Slicer/Slicer.h \
 	../../../XlsxFormat/NamedSheetViews/NamedSheetViews.h \
+        ../../../XlsxFormat/Workbook/FeaturePropertyBag.h \
         ../../../XlsxFormat/Workbook/Metadata.h \
         ../../../XlsxFormat/RichData/RdRichValue.h \
         ../../../VsdxFormat/Vsdx.h \

--- a/OOXML/Projects/Windows/DocxFormatLib/DocxFormatLib.vcxproj
+++ b/OOXML/Projects/Windows/DocxFormatLib/DocxFormatLib.vcxproj
@@ -396,6 +396,7 @@
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\CustomsXml.h" />
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\DefinedNames.h" />
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\ExternalReferences.h" />
+    <ClInclude Include="..\..\..\XlsxFormat\Workbook\FeaturePropertyBag.h" />
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\Metadata.h" />
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\Sheets.h" />
     <ClInclude Include="..\..\..\XlsxFormat\Workbook\Workbook.h" />
@@ -567,6 +568,7 @@
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\CustomsXml.cpp" />
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\DefinedNames.cpp" />
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\ExternalReferences.cpp" />
+    <ClCompile Include="..\..\..\XlsxFormat\Workbook\FeaturePropertyBag.cpp" />
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\Metadata.cpp" />
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\Sheets.cpp" />
     <ClCompile Include="..\..\..\XlsxFormat\Workbook\Workbook.cpp" />

--- a/OOXML/XlsxFormat/FileFactory_Spreadsheet.cpp
+++ b/OOXML/XlsxFormat/FileFactory_Spreadsheet.cpp
@@ -54,6 +54,7 @@
 #include "Timelines/Timeline.h"
 #include "RichData/RdRichData.h"
 #include "Workbook/Metadata.h"
+#include "Workbook/FeaturePropertyBag.h"
 
 #include "Table/Table.h"
 #include "Table/QueryTable.h"
@@ -183,6 +184,8 @@ namespace OOX
 				return smart_ptr<OOX::File>(new CTimelineCacheFile(pMain, oRootPath, oFileName));
 			else if (oRelation.Type() == FileTypes::Metadata)
 				return smart_ptr<OOX::File>(new CMetadataFile(pMain, oRootPath, oFileName));
+			else if (oRelation.Type() == FileTypes::FeaturePropertyBag)
+				return smart_ptr<OOX::File>(new CFeaturePropertyBagFile(pMain, oRootPath, oFileName));
 			else if (oRelation.Type() == FileTypes::RdRichValueStructure)
 				return smart_ptr<OOX::File>(new CRdRichValueStructureFile(pMain, oRootPath, oFileName));
 			else if (oRelation.Type() == FileTypes::RdRichValue)
@@ -325,6 +328,8 @@ namespace OOX
 				return smart_ptr<OOX::File>(new CTimelineCacheFile(pMain, oRootPath, oFileName));
 			else if (pRelation->Type() == FileTypes::Metadata)
 				return smart_ptr<OOX::File>(new CMetadataFile(pMain, oRootPath, oFileName));
+			else if (pRelation->Type() == FileTypes::FeaturePropertyBag)
+				return smart_ptr<OOX::File>(new CFeaturePropertyBagFile(pMain, oRootPath, oFileName));
 			else if (pRelation->Type() == FileTypes::RdRichValueStructure)
 				return smart_ptr<OOX::File>(new CRdRichValueStructureFile(pMain, oRootPath, oFileName));
 			else if (pRelation->Type() == FileTypes::RdRichValue)

--- a/OOXML/XlsxFormat/FileTypes_Spreadsheet.cpp
+++ b/OOXML/XlsxFormat/FileTypes_Spreadsheet.cpp
@@ -161,6 +161,10 @@ namespace OOX
 												L"application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml",
 												L"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata");
 
+			const FileType FeaturePropertyBag(L"featurePropertyBag", L"featurePropertyBag.xml",
+												L"application/vnd.ms-excel.featurepropertybag+xml",
+												L"http://schemas.microsoft.com/office/2022/11/relationships/FeaturePropertyBag");
+
 
 			const FileType RdRichValue		(L"richData", L"rdrichvalue.xml",
 												L"application/vnd.ms-excel.rdrichvalue+xml",

--- a/OOXML/XlsxFormat/FileTypes_Spreadsheet.h
+++ b/OOXML/XlsxFormat/FileTypes_Spreadsheet.h
@@ -90,6 +90,8 @@ namespace OOX
 
 			extern const FileType Metadata;
 
+			extern const FileType FeaturePropertyBag;
+
 			extern const FileType RdRichValue;
 
 			extern const FileType RdRichValueStructure;

--- a/OOXML/XlsxFormat/Styles/Xfs.cpp
+++ b/OOXML/XlsxFormat/Styles/Xfs.cpp
@@ -351,12 +351,20 @@ namespace OOX
 			WritingStringNullableAttrBool(L"applyProtection", m_oApplyProtection);
 			WritingStringNullableAttrBool(L"quotePrefix", m_oQuotePrefix);
 			WritingStringNullableAttrBool(L"pivotButton", m_oPivotButton);
-			if (m_oAligment.IsInit() || m_oProtection.IsInit())
+			bool bCellControl = m_oCellControl.IsInit() ? *m_oCellControl : m_oXfComplementIndex.IsInit();
+			if (m_oAligment.IsInit() || m_oProtection.IsInit() || bCellControl)
 			{
 				writer.WriteString(_T(">"));
 
 				if (m_oAligment.IsInit())m_oAligment->toXML(writer);
 				if (m_oProtection.IsInit())m_oProtection->toXML(writer);
+				if (bCellControl)
+				{
+					// references the canonical checkbox chain in featurePropertyBag.xml
+					writer.WriteString(L"<extLst><ext uri=\"{C7286773-470A-42A8-94C5-96B5CB345126}\" \
+xmlns:xfpb=\"http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag\">\
+<xfpb:xfComplement i=\"0\"/></ext></extLst>");
+				}
 
 				writer.WriteString(_T("</xf>"));
 			}
@@ -378,6 +386,42 @@ namespace OOX
 					m_oAligment = oReader;
 				else if( _T("protection") == sName )
 					m_oProtection = oReader;
+				else if( _T("extLst") == sName )
+					ReadExtLst(oReader);
+			}
+		}
+		void CXfs::ReadExtLst(XmlUtils::CXmlLiteReader& oReader)
+		{
+			if (oReader.IsEmptyNode())
+				return;
+
+			int nExtLstDepth = oReader.GetDepth();
+			while (oReader.ReadNextSiblingNode(nExtLstDepth))
+			{
+				if (L"ext" != XmlUtils::GetNameNoNS(oReader.GetName()) || oReader.IsEmptyNode())
+					continue;
+
+				int nExtDepth = oReader.GetDepth();
+				while (oReader.ReadNextSiblingNode(nExtDepth))
+				{
+					if (L"xfComplement" == XmlUtils::GetNameNoNS(oReader.GetName()))
+					{
+						if (oReader.MoveToFirstAttribute())
+						{
+							std::wstring wsName = oReader.GetName();
+							while (!wsName.empty())
+							{
+								if (L"i" == wsName)
+									m_oXfComplementIndex = XmlUtils::GetInteger(oReader.GetText());
+
+								if (!oReader.MoveToNextAttribute())
+									break;
+								wsName = oReader.GetName();
+							}
+							oReader.MoveToElement();
+						}
+					}
+				}
 			}
 		}
 		EElementType CXfs::getType () const

--- a/OOXML/XlsxFormat/Styles/Xfs.h
+++ b/OOXML/XlsxFormat/Styles/Xfs.h
@@ -112,8 +112,6 @@ namespace OOX
 			nullable<SimpleTypes::COnOff> m_oLocked;
 		};
 
-		//нереализован:
-		//<extLst>
 		class CXfs : public WritingElement
 		{
 		public:
@@ -137,6 +135,7 @@ namespace OOX
 		private:
 			void ReadAttributes(XmlUtils::CXmlLiteReader& oReader);
 			void ReadAttributes(XLS::BaseObjectPtr& obj);
+			void ReadExtLst(XmlUtils::CXmlLiteReader& oReader);
 
 		public:
 			nullable<SimpleTypes::COnOff>					m_oApplyAlignment;
@@ -157,6 +156,10 @@ namespace OOX
 			nullable<CAligment>								m_oAligment;
 			nullable<CProtection>							m_oProtection;
 
+			// cell checkbox (resolved from the featurePropertyBag xfComplement extension)
+			nullable_bool									m_oCellControl;
+			// raw <xfpb:xfComplement i="..."/> index, resolved via CFeaturePropertyBagFile
+			nullable_int									m_oXfComplementIndex;
 		};
 
 		class CCellXfs  : public WritingElementWithChilds<CXfs>

--- a/OOXML/XlsxFormat/Workbook/FeaturePropertyBag.cpp
+++ b/OOXML/XlsxFormat/Workbook/FeaturePropertyBag.cpp
@@ -1,0 +1,199 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2023
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ */
+#include "FeaturePropertyBag.h"
+
+#include "../FileTypes_Spreadsheet.h"
+
+#include "../../../DesktopEditor/common/File.h"
+#include "../../../DesktopEditor/xml/include/xmlutils.h"
+#include "../../Base/Unit.h"
+
+namespace OOX
+{
+	namespace Spreadsheet
+	{
+		CFeaturePropertyBagFile::CFeaturePropertyBagFile(OOX::Document* pMain) : OOX::File(pMain)
+		{
+		}
+		CFeaturePropertyBagFile::CFeaturePropertyBagFile(OOX::Document* pMain, const CPath& oRootPath, const CPath& oPath) : OOX::File(pMain)
+		{
+			read(oRootPath, oPath);
+		}
+		CFeaturePropertyBagFile::~CFeaturePropertyBagFile()
+		{
+		}
+		void CFeaturePropertyBagFile::read(const CPath& oPath)
+		{
+			CPath oRootPath;
+			read(oRootPath, oPath);
+		}
+		const OOX::FileType CFeaturePropertyBagFile::type() const
+		{
+			return OOX::Spreadsheet::FileTypes::FeaturePropertyBag;
+		}
+		const CPath CFeaturePropertyBagFile::DefaultDirectory() const
+		{
+			return type().DefaultDirectory();
+		}
+		const CPath CFeaturePropertyBagFile::DefaultFileName() const
+		{
+			return type().DefaultFileName();
+		}
+		void CFeaturePropertyBagFile::read(const CPath& oRootPath, const CPath& oPath)
+		{
+			XmlUtils::CXmlLiteReader oReader;
+
+			if (!oReader.FromFile(oPath.GetPath()))
+				return;
+			if (!oReader.ReadNextNode())
+				return;
+			if (L"FeaturePropertyBags" != XmlUtils::GetNameNoNS(oReader.GetName()))
+				return;
+			if (oReader.IsEmptyNode())
+				return;
+
+			int nBagsDepth = oReader.GetDepth();
+			while (oReader.ReadNextSiblingNode(nBagsDepth))
+			{
+				if (L"bag" != XmlUtils::GetNameNoNS(oReader.GetName()))
+					continue;
+
+				Bag oBag;
+				if (oReader.MoveToFirstAttribute())
+				{
+					std::wstring wsName = oReader.GetName();
+					while (!wsName.empty())
+					{
+						if (L"type" == wsName)
+							oBag.sType = oReader.GetText();
+
+						if (!oReader.MoveToNextAttribute())
+							break;
+						wsName = oReader.GetName();
+					}
+					oReader.MoveToElement();
+				}
+				if (false == oReader.IsEmptyNode())
+				{
+					int nBagDepth = oReader.GetDepth();
+					while (oReader.ReadNextSiblingNode(nBagDepth))
+					{
+						std::wstring sName = XmlUtils::GetNameNoNS(oReader.GetName());
+						if (L"bagId" == sName)
+						{
+							std::wstring sKey;
+							if (oReader.MoveToFirstAttribute())
+							{
+								std::wstring wsName = oReader.GetName();
+								while (!wsName.empty())
+								{
+									if (L"k" == wsName)
+										sKey = oReader.GetText();
+
+									if (!oReader.MoveToNextAttribute())
+										break;
+									wsName = oReader.GetName();
+								}
+								oReader.MoveToElement();
+							}
+							oBag.mapBagIds[sKey] = XmlUtils::GetInteger(oReader.GetText3());
+						}
+						else if (L"a" == sName)
+						{
+							if (oReader.IsEmptyNode())
+								continue;
+
+							int nArrayDepth = oReader.GetDepth();
+							while (oReader.ReadNextSiblingNode(nArrayDepth))
+							{
+								if (L"bagId" == XmlUtils::GetNameNoNS(oReader.GetName()))
+									oBag.arrMappedBagIds.push_back(XmlUtils::GetInteger(oReader.GetText3()));
+							}
+						}
+					}
+				}
+				m_arrBags.push_back(oBag);
+			}
+		}
+		bool CFeaturePropertyBagFile::IsCheckboxComplement(int nIndex) const
+		{
+			// xfComplement i -> XFComplements/MappedFeaturePropertyBags[i] -> XFComplement
+			// -> XFControls -> CellControl -> bag type "Checkbox"
+			const Bag* pComplements = NULL;
+			for (size_t i = 0; i < m_arrBags.size(); ++i)
+			{
+				if (L"XFComplements" == m_arrBags[i].sType)
+				{
+					pComplements = &m_arrBags[i];
+					break;
+				}
+			}
+			if (NULL == pComplements || nIndex < 0 || nIndex >= (int)pComplements->arrMappedBagIds.size())
+				return false;
+
+			int nComplementId = pComplements->arrMappedBagIds[nIndex];
+			if (nComplementId < 0 || nComplementId >= (int)m_arrBags.size())
+				return false;
+
+			const Bag& oComplement = m_arrBags[nComplementId];
+			std::map<std::wstring, int>::const_iterator itControls = oComplement.mapBagIds.find(L"XFControls");
+			if (oComplement.sType != L"XFComplement" || itControls == oComplement.mapBagIds.end())
+				return false;
+
+			int nControlsId = itControls->second;
+			if (nControlsId < 0 || nControlsId >= (int)m_arrBags.size())
+				return false;
+
+			const Bag& oControls = m_arrBags[nControlsId];
+			std::map<std::wstring, int>::const_iterator itControl = oControls.mapBagIds.find(L"CellControl");
+			if (oControls.sType != L"XFControls" || itControl == oControls.mapBagIds.end())
+				return false;
+
+			int nControlId = itControl->second;
+			if (nControlId < 0 || nControlId >= (int)m_arrBags.size())
+				return false;
+
+			return L"Checkbox" == m_arrBags[nControlId].sType;
+		}
+		void CFeaturePropertyBagFile::write(const CPath& oPath, const CPath& oDirectory, CContentTypes& oContent) const
+		{
+			// canonical content: a single Checkbox control chain; every checkbox xf
+			// references it via <xfpb:xfComplement i="0"/>
+			std::wstring sXml = L"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+				L"<FeaturePropertyBags xmlns=\"http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag\">"
+				L"<bag type=\"Checkbox\"/>"
+				L"<bag type=\"XFControls\"><bagId k=\"CellControl\">0</bagId></bag>"
+				L"<bag type=\"XFComplement\"><bagId k=\"XFControls\">1</bagId></bag>"
+				L"<bag type=\"XFComplements\" extRef=\"XFComplementsMapperExtRef\">"
+				L"<a k=\"MappedFeaturePropertyBags\"><bagId>2</bagId></a>"
+				L"</bag>"
+				L"</FeaturePropertyBags>";
+
+			NSFile::CFileBinary::SaveToFile(oPath.GetPath(), sXml);
+
+			oContent.Registration(type().OverrideType(), oDirectory, oPath.GetFilename());
+		}
+	}
+} // namespace OOX

--- a/OOXML/XlsxFormat/Workbook/FeaturePropertyBag.h
+++ b/OOXML/XlsxFormat/Workbook/FeaturePropertyBag.h
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2023
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ */
+#pragma once
+
+#include "../../DocxFormat/File.h"
+
+#include <map>
+#include <vector>
+
+namespace OOX
+{
+	namespace Spreadsheet
+	{
+		// xl/featurePropertyBag/featurePropertyBag.xml
+		// Stores feature property bags; currently the only consumer is the cell checkbox
+		// feature: an <xf> extLst references an XFComplements entry which resolves through
+		// XFComplement -> XFControls (CellControl) to a bag of type "Checkbox".
+		class CFeaturePropertyBagFile : public OOX::File
+		{
+		public:
+			CFeaturePropertyBagFile(OOX::Document* pMain);
+			CFeaturePropertyBagFile(OOX::Document* pMain, const CPath& oRootPath, const CPath& oPath);
+			virtual ~CFeaturePropertyBagFile();
+
+			virtual void read(const CPath& oPath);
+			virtual void read(const CPath& oRootPath, const CPath& oPath);
+			virtual void write(const CPath& oPath, const CPath& oDirectory, CContentTypes& oContent) const;
+
+			virtual const OOX::FileType type() const;
+			virtual const CPath DefaultDirectory() const;
+			virtual const CPath DefaultFileName() const;
+
+			// true if the XFComplements entry at nIndex resolves to a Checkbox cell control
+			bool IsCheckboxComplement(int nIndex) const;
+
+		private:
+			struct Bag
+			{
+				std::wstring sType;
+				std::map<std::wstring, int> mapBagIds;	// <bagId k="...">N</bagId>
+				std::vector<int> arrMappedBagIds;		// <a k="MappedFeaturePropertyBags"><bagId>N</bagId>...</a>
+			};
+			std::vector<Bag> m_arrBags;
+		};
+	}
+} // namespace OOX


### PR DESCRIPTION
Adds xlsx ↔ Editor.bin support for Excel's modern cell checkbox feature.

- Parse `xl/featurePropertyBag/featurePropertyBag.xml` and resolve the per-xf `xfComplement` chain into a boolean checkbox flag on the cell xf.
- Carry the flag through Editor.bin as a new xf property (`c_oSerXfsTypes::CellControl`).
- On write, regenerate the canonical featurePropertyBag part + per-xf `extLst` (cellXfs and cellStyleXfs).

Verified by round-tripping a checkbox file (D8) xlsx → bin → xlsx: the part, relationship, content-type and xf extLst all survive (confirmed absent on the pre-change build).

Note: independent/alternative implementation; an existing `feature/checkbox` branch also implements this (with ODF support). Opened for comparison. xlsb path intentionally out of scope.