### PR TITLE
fix: enable TLS certificate verification in FileTransporter

### DIFF
--- a/Common/Network/FileTransporter/src/FileTransporter_curl.cpp
+++ b/Common/Network/FileTransporter/src/FileTransporter_curl.cpp
@@ -113,11 +113,12 @@ namespace NSNetwork
 					//curl_easy_setopt(curl, CURLOPT_NOPROGRESS, FALSE);
 					// Install the callback function
 					//curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_func);
-#if defined(__linux__)
-					//Linux doesn't have root certificates built into the system, so we disable verification
-					//http://curl.haxx.se/docs/sslcerts.html
-					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-#endif
+					// Verify the peer's TLS certificate against the system CA store.
+					// These are libcurl defaults; set explicitly so the bypass is not
+					// reintroduced. If a platform lacks a default CA bundle, configure
+					// it via CURLOPT_CAINFO/CURLOPT_CAPATH rather than disabling verification.
+					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
 					/* tell libcurl to follow redirection(default false) */
 					curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 					/* some servers don't like requests that are made without a user-agent field, so we provide one */
@@ -173,11 +174,12 @@ namespace NSNetwork
 					curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data_to_string);
 					curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
 
-#if defined(__linux__)
-					//Linux doesn't have root certificates built into the system, so we disable verification
-					//http://curl.haxx.se/docs/sslcerts.html
-					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-#endif
+					// Verify the peer's TLS certificate against the system CA store.
+					// These are libcurl defaults; set explicitly so the bypass is not
+					// reintroduced. If a platform lacks a default CA bundle, configure
+					// it via CURLOPT_CAINFO/CURLOPT_CAPATH rather than disabling verification.
+					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+					curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
 
 					/* Perform the request, res will get the return code */
 					res = curl_easy_perform(curl);


### PR DESCRIPTION
## Summary

The cURL-based file transporter (`Common/Network/FileTransporter/src/FileTransporter_curl.cpp`) disabled TLS peer certificate verification on Linux — `CURLOPT_SSL_VERIFYPEER, 0L` — for **both** downloads (`DownloadData`) and uploads (`UploadData`). The original comment justified it with "Linux doesn't have root certificates built into the system".

That premise is no longer true: every mainstream distribution ships a system CA bundle (e.g. `/etc/ssl/certs`). The only effect of the bypass was to make all HTTPS transfers vulnerable to man-in-the-middle attacks — including uploads, which can carry document data.

## Changes

- Remove the `#if defined(__linux__)` blocks that set `CURLOPT_SSL_VERIFYPEER, 0L` at both call sites.
- Explicitly enable `CURLOPT_SSL_VERIFYPEER, 1L` and `CURLOPT_SSL_VERIFYHOST, 2L` so the secure default is documented in-place and cannot be silently reintroduced.

## Notes / compatibility

- These values are libcurl's defaults; setting them explicitly is for clarity and regression-safety.
- If a deployment target genuinely lacks a default CA bundle, the correct fix is to provide one via `CURLOPT_CAINFO` / `CURLOPT_CAPATH`, **not** to disable verification. On such targets, affected HTTPS requests will now fail fast instead of proceeding insecurely.
- The `--no-check-certificate` wget fallback in `transport_external.h` is left untouched: it is gated to `OLD_MACOS_SYSTEM` and outside the Linux code path.