### PR TITLE
Switch Emscripten SDK image to custom registry

### DIFF
--- a/.docker/core-wasm.bake.Dockerfile
+++ b/.docker/core-wasm.bake.Dockerfile
@@ -8,7 +8,7 @@
 # ==============================================================================
 
 #### CORE WASM ####
-FROM emscripten/emsdk:5.0.4 AS core-wasm 
+FROM ghcr.io/euro-office/emsdk:5.0.4 AS core-wasm
     ARG BUILD_ROOT
     ARG CACHE_BUST
     ARG NUGET_SOURCE_PATH

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -16,7 +16,7 @@ jobs:
   build-wasm:
     runs-on: [ubuntu-latest, self-hosted]
     container:
-        image: emscripten/emsdk:5.0.4
+        image: ghcr.io/euro-office/emsdk:5.0.4
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
This PR updates the Emscripten SDK Docker image references from the public Docker Hub registry to a custom GitHub Container Registry (GHCR) image maintained by euro-office.

## Changes
- Updated Dockerfile base image reference in `.docker/core-wasm.bake.Dockerfile` from `emscripten/emsdk:5.0.4` to `ghcr.io/euro-office/emsdk:5.0.4`
- Updated container image reference in `.github/workflows/build-wasm.yml` from `emscripten/emsdk:5.0.4` to `ghcr.io/euro-office/emsdk:5.0.4`

## Details
Both the Docker build configuration and GitHub Actions workflow now pull the Emscripten SDK from the custom GHCR registry instead of the public Docker Hub. The image version remains at 5.0.4. This change likely enables better control over the build environment and potentially faster image pulls from the GitHub Container Registry.

## AI tool use disclosure
This change was prepared with AI assistance (Claude Code). All commits include an `Assisted-by` trailer.

https://claude.ai/code/session_01Vm1SbxrKUqStFTZ5DdRQkf