### PR TITLE
Refactor WASM build workflow with conditional execution

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -2,18 +2,34 @@ name: Build WASM
 
 on:
   pull_request:
-    paths:
-      - '**/wasm/**'
-      - 'DesktopEditor/graphics/pro/js/**'
-      - 'DesktopEditor/fontengine/js/**'
-      - 'DesktopEditor/doctrenderer/**'
-      - 'OfficeUtils/js/**'
-      - '**/CMakeLists.txt'
-      - '**/*.cmake'
-      - '.github/workflows/build-wasm.yml'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      wasm: ${{ steps.filter.outputs.wasm }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            wasm:
+              - '**/wasm/**'
+              - 'DesktopEditor/graphics/pro/js/**'
+              - 'DesktopEditor/fontengine/js/**'
+              - 'DesktopEditor/doctrenderer/**'
+              - 'OfficeUtils/js/**'
+              - '**/CMakeLists.txt'
+              - '**/*.cmake'
+              - '.github/workflows/build-wasm.yml'
+
   build-wasm:
+    needs: changes
+    if: needs.changes.outputs.wasm == 'true'
     runs-on: [ubuntu-latest, self-hosted]
     container:
         image: ghcr.io/euro-office/emsdk:5.0.4
@@ -57,3 +73,22 @@ jobs:
           cd ../build-wasm-dir
           /bin/bash -c "emcmake cmake -S $GITHUB_WORKSPACE/core -B . -DEO_CORE_OUTPUT_DIR=$GITHUB_WORKSPACE/package && cmake --build ."
         shell: bash
+
+  build-wasm-summary:
+    # Aggregate job so branch protection can require a single, always-reported
+    # check regardless of whether the build actually ran for this PR.
+    needs: [changes, build-wasm]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check build result
+        run: |
+          result="${{ needs.build-wasm.result }}"
+          echo "build-wasm result: $result"
+          # Pass when the build succeeded or was skipped (no relevant changes).
+          if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+            echo "WASM build did not fail."
+            exit 0
+          fi
+          echo "WASM build failed (result: $result)."
+          exit 1


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow for WASM builds to use conditional job execution based on path changes, improving CI efficiency by skipping unnecessary builds when relevant files haven't been modified.

## Key Changes
- **Extracted path filtering into separate job**: Created a new `changes` job that uses `dorny/paths-filter@v3` to detect modifications to WASM-related files, replacing the inline `paths` trigger configuration
- **Added conditional build execution**: The `build-wasm` job now depends on the `changes` job and only runs when relevant files are modified (`if: needs.changes.outputs.wasm == 'true'`)
- **Introduced summary job**: Added `build-wasm-summary` job that aggregates results from both `changes` and `build-wasm` jobs, ensuring a consistent check is always reported to branch protection rules regardless of whether the build was skipped

## Implementation Details
- The `changes` job outputs a `wasm` flag indicating whether WASM-related files were modified
- The `build-wasm-summary` job uses `if: always()` to run regardless of upstream job results, and exits with success if the build either succeeded or was skipped (no relevant changes detected)
- This pattern allows branch protection to require a single, always-reported status check while still optimizing CI by skipping builds when unnecessary

## AI Disclosure
This pull request was prepared with the assistance of an AI coding tool (Claude Code). All changes have been reviewed before submission.

https://claude.ai/code/session_011EZjFBEBrxvey4nreJ4jTi