### PR TITLE
ci: run e2e overlay on nightly at end of build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,3 +132,82 @@ jobs:
       with:
         path: ${{ github.workspace }}/.cache/ccache
         key: ccache-${{ runner.os }}-clang13-${{ github.run_id }}
+
+    # ─────────────────────────────────────────────────────────────
+    # E2E: overlay the freshly built core binaries onto the published
+    # nightly image and run the DocumentServer Playwright suite. Reuses
+    # the binaries already produced in build/package above, so it adds
+    # no extra compile cost. Unique port + container name avoid colliding
+    # with the DocumentServer e2e job on the shared self-hosted host.
+    # ─────────────────────────────────────────────────────────────
+    - name: Check out DocumentServer e2e (current branch)
+      id: docserver
+      uses: actions/checkout@v4
+      continue-on-error: true
+      with:
+        repository: Euro-Office/DocumentServer
+        path: documentserver
+        ref: ${{ github.head_ref || github.ref_name }}
+    - name: Check out DocumentServer e2e (main)
+      if: steps.docserver.outcome != 'success'
+      uses: actions/checkout@v4
+      with:
+        repository: Euro-Office/DocumentServer
+        path: documentserver
+        ref: main
+
+    - name: Use Node.js 20 for e2e
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Pull nightly image
+      run: docker pull ghcr.io/euro-office/documentserver:nightly
+
+    - name: Build overlay image with fresh core binaries
+      run: |
+        set -euo pipefail
+        cat > overlay.Dockerfile <<'EOF'
+        ARG NIGHTLY_IMAGE
+        FROM ${NIGHTLY_IMAGE}
+        COPY . /tmp/core/
+        # The install path is brand-derived (/var/www/<brand>/documentserver);
+        # locate it via the sdkjs dir, then overlay the FileConverter binaries,
+        # tools and shared libraries (mirrors bundle.bake.Dockerfile).
+        RUN set -eux; \
+            root="$(dirname "$(find /var/www -maxdepth 5 -type d -name sdkjs -path '*documentserver*' | head -n1)")"; \
+            test -n "$root"; \
+            cp -a /tmp/core/bin/.   "$root/server/FileConverter/bin/"; \
+            cp -a /tmp/core/tools/. "$root/server/tools/"; \
+            for f in /tmp/core/*.so*; do [ -e "$f" ] && cp -a "$f" "$root/server/FileConverter/lib/"; done; \
+            rm -rf /tmp/core
+        EOF
+        docker build \
+          --build-arg NIGHTLY_IMAGE=ghcr.io/euro-office/documentserver:nightly \
+          -t euro-office/documentserver:e2e-core \
+          -f overlay.Dockerfile \
+          build/package
+
+    - name: Install e2e dependencies
+      working-directory: documentserver/e2e
+      run: npm ci
+
+    - name: Install Playwright browsers
+      working-directory: documentserver/e2e
+      run: npx playwright install chromium --with-deps
+
+    - name: Run E2E tests
+      working-directory: documentserver/e2e
+      env:
+        E2E_IMAGE: euro-office/documentserver:e2e-core
+        E2E_HOST_PORT: 8989
+        E2E_CONTAINER_NAME: euro-office-e2e-core
+      run: npm test
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-${{ github.sha }}
+        path: documentserver/e2e/playwright-report/
+        retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,15 +171,24 @@ jobs:
         ARG NIGHTLY_IMAGE
         FROM ${NIGHTLY_IMAGE}
         COPY . /tmp/core/
-        # The install path is brand-derived (/var/www/<brand>/documentserver);
-        # locate it via the sdkjs dir, then overlay the FileConverter binaries,
-        # tools and shared libraries (mirrors bundle.bake.Dockerfile).
-        RUN set -eux; \
+        # The CI build emits a flat build/package (binaries, tools and .so libs
+        # together), unlike the bake which splits bin/tools. Rather than assume a
+        # layout, overlay by filename: replace each same-named file already present
+        # in the image's server tree (FileConverter/bin, FileConverter/lib,
+        # server/tools). Fail if nothing matched, so a layout drift can't silently
+        # pass. The install path is brand-derived; locate it via the sdkjs dir.
+        RUN set -eu; \
             root="$(dirname "$(find /var/www -maxdepth 5 -type d -name sdkjs -path '*documentserver*' | head -n1)")"; \
             test -n "$root"; \
-            cp -a /tmp/core/bin/.   "$root/server/FileConverter/bin/"; \
-            cp -a /tmp/core/tools/. "$root/server/tools/"; \
-            for f in /tmp/core/*.so*; do [ -e "$f" ] && cp -a "$f" "$root/server/FileConverter/lib/"; done; \
+            count=0; \
+            for f in $(find /tmp/core -type f); do \
+              name="$(basename "$f")"; \
+              for t in $(find "$root/server" -type f -name "$name"); do \
+                cp -af "$f" "$t"; count=$((count+1)); echo "overlaid $name -> $t"; \
+              done; \
+            done; \
+            echo "total files replaced: $count"; \
+            [ "$count" -gt 0 ]; \
             rm -rf /tmp/core
         EOF
         docker build \


### PR DESCRIPTION
Appends an e2e stage to the end of the existing `build` job. After core is built and its CTest/conversion tests pass, the freshly built `build/package` binaries are overlaid onto `ghcr.io/euro-office/documentserver:nightly` and the DocumentServer Playwright e2e suite runs against it.

## How it works
- Reuses the binaries already produced by the build, so it adds **no extra compile cost**.
- The CI build emits a flat `build/package` (binaries, tools and `.so` libs together), unlike the bake which splits `bin/`/`tools/`. The overlay therefore replaces files **by filename** — each same-named file already present in the image's `server/` tree (FileConverter `bin`/`lib`, `server/tools`) — and **fails if nothing matched**, so a layout drift cannot silently pass. Install path discovered via the `sdkjs` dir.
- Runs the e2e suite from `Euro-Office/DocumentServer` (matching branch, fallback `main`) on the same self-hosted runner, with a unique host port (8989) and container name to avoid colliding with the DocumentServer e2e job.

The documentserver package is public, so the image pulls anonymously.

## Verification
A temporary canary (force x2t to fail at runtime + skip CTest/conversion so the job reaches the e2e stage) confirmed the e2e turns red on a regression — it failed at *Run E2E tests* as expected. This also surfaced and fixed a real overlay bug (flat `build/package` vs the bake's `bin/tools` split — hence the filename-match approach). The canary has been removed; the overlay fix is kept.