### PR TITLE
fix(openssl-hash): eliminate flaky WASM build by sequencing build_generated before parallel make

### DIFF
--- a/Common/3dParty/openssl-hash/nc-build.py
+++ b/Common/3dParty/openssl-hash/nc-build.py
@@ -96,11 +96,19 @@ def build_and_install():
         except Exception as e:
             nc.abort_op( "Failed to fix Makefile" )
 
+        # build_generated must complete before parallel compilation starts,
+        # otherwise opensslconf.h may not exist yet when .c files are compiled.
+        nc.run_command(
+            [   "emmake", "make", "build_generated" ],
+            "Generate headers",
+            nc.work_dir,
+            env = env
+        )
+
         nc.run_command(
             [   "emmake",
                 "make",
                 f"-j{os.cpu_count()}",
-                "build_generated",
                 "libcrypto.a",
                 "libssl.a",
             ],


### PR DESCRIPTION
## Problem

`build-wasm` CI fails non-deterministically due to a race condition in `Common/3dParty/openssl-hash/nc-build.py`.

The build ran:
```sh
emmake make -j<N> build_generated libcrypto.a libssl.a
```

Make is free to compile `libcrypto.a`/`libssl.a` object files concurrently with `build_generated`, but `build_generated` generates `opensslconf.h` which defines `BN_ULONG`, `DEPRECATEDIN_*` macros, and `OPENSSL_FILE`/`OPENSSL_LINE`. Files compiled before `opensslconf.h` exists fail with missing-type errors. Because scheduling is non-deterministic, the race is won or lost randomly — 2 of 6 runs on PR #103 failed this way.

## Fix

Split into two sequential calls:
1. `emmake make build_generated` — wait for header generation
2. `emmake make -j<N> libcrypto.a libssl.a` — now safe to parallelise

---
> **AI disclosure:** This fix was identified and implemented with the assistance of Claude Code (claude-sonnet-4-6).