### PR TITLE
Fix malformed HTML structure in md2html conversion

### DIFF
--- a/Common/3dParty/md/md2html.cpp
+++ b/Common/3dParty/md/md2html.cpp
@@ -79,13 +79,15 @@ bool ConvertMdFileToHtml(const std::wstring& wsPathToMdFile, const std::wstring&
 	if (!oFile.CreateFile(wsPathToHtmlFile))
 		return false;
 
-	oFile.WriteStringUTF8(L"<html><body>");
+	oFile.WriteStringUTF8(L"<html>");
 
 	oFile.WriteStringUTF8(L"<head>");
 	//oFile.WriteStringUTF8(L"<meta charset=\"UTF-8\">");
 	oFile.WriteStringUTF8(L"<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">");
 	WriteBaseHtmlStyles(oFile);
 	oFile.WriteStringUTF8(L"</head>");
+
+	oFile.WriteStringUTF8(L"<body>");
 
 	bool bResult = true;
 


### PR DESCRIPTION
## What

`ConvertMdFileToHtml` opened `<body>` *before* `<head>`, nesting the `<head>` (meta charset + heading/table/code styles from `WriteBaseHtmlStyles`) inside the body:

```
<html><body><head>…styles…</head>CONTENT</body></html>   ← before
<html><head>…styles…</head><body>CONTENT</body></html>   ← after
```

These styles drive heading sizes, table borders, and blockquote/code rendering when the intermediate HTML is parsed back into a document, so correct placement improves md → docx/odt/etc. fidelity. Pure structural change, no logic change.

## Context

Found while reviewing markdown support for #65. Note: markdown conversion is already implemented in `core` (bidirectional, GitHub-flavored) — see the comment on that issue for details.

## Testing

Not built locally (full build pulls vcpkg deps). The change is a static reordering of literal HTML output.

Agentic Model: Claude Opus 4.8