### PR TITLE
fix(OfficeUtils): strengthen ZipSlip path traversal protection in ZIP extraction

### DIFF
--- a/OfficeUtils/src/ZipUtilsCP.cpp
+++ b/OfficeUtils/src/ZipUtilsCP.cpp
@@ -288,15 +288,55 @@ namespace ZLibZipUtils
 			err = unzOpenCurrentFilePassword(uf, password);
 
 			//-------------------------------------------------------------------------------------------------
-
+			// ZipSlip protection: verify the resolved output path stays within unzip_dir
 			if (unzip_dir)
 			{
-				const std::wstring wsFilePath{NSSystemPath::ShortenPath(filenameW)};
+				// Normalize the filename to resolve any ../ or ./ components
+				const std::wstring wsNormalizedFilename = NSSystemPath::ShortenPath(filenameW);
 
-				if (wsFilePath.size() > 3 && L'.' == wsFilePath[0] && L'.' == wsFilePath[1] && L'/' == wsFilePath[2])
+				// Reject if normalization produced an empty path
+				if (wsNormalizedFilename.empty())
 					return UNZ_INTERNALERROR;
-			}
 
+				// Reject absolute paths in the archive entry itself
+#if defined(_WIN32) || defined (_WIN64)
+				bool bIsAbsolute = false;
+				// Drive letter: C:\ or C:/
+				if (wsNormalizedFilename.size() >= 2 &&
+					wsNormalizedFilename[1] == L':' &&
+					(wsNormalizedFilename[0] >= L'A' && wsNormalizedFilename[0] <= L'Z' ||
+					 wsNormalizedFilename[0] >= L'a' && wsNormalizedFilename[0] <= L'z'))
+					bIsAbsolute = true;
+				// UNC path: \\server\share
+				if (wsNormalizedFilename.size() >= 2 &&
+					wsNormalizedFilename[0] == L'\\' && wsNormalizedFilename[1] == L'\\')
+					bIsAbsolute = true;
+				if (bIsAbsolute)
+					return UNZ_INTERNALERROR;
+#else
+				// Unix-like: absolute path starting with /
+				if (!wsNormalizedFilename.empty() && wsNormalizedFilename[0] == L'/')
+					return UNZ_INTERNALERROR;
+#endif
+
+				// Build the normalized output path and verify containment within unzip_dir
+				std::wstring wsNormalizedOutput = NSSystemPath::ShortenPath(output);
+				std::wstring wsNormalizedDir    = NSSystemPath::ShortenPath(unzip_dir);
+
+				// Ensure directory ends with separator for proper prefix matching
+				if (!wsNormalizedDir.empty() &&
+					wsNormalizedDir.back() != L'/' && wsNormalizedDir.back() != L'\\')
+				{
+					wsNormalizedDir += FILE_SEPARATOR_STR;
+				}
+
+				// Verify the output path starts with the extraction directory prefix
+				if (wsNormalizedOutput.size() < wsNormalizedDir.size() ||
+					wsNormalizedOutput.substr(0, wsNormalizedDir.size()) != wsNormalizedDir)
+				{
+					return UNZ_INTERNALERROR;
+				}
+			}
 			//-------------------------------------------------------------------------------------------------
 			NSFile::CFileBinary oFile;
 			FILE *fout = NULL;


### PR DESCRIPTION
## Summary

Addresses [Euro-Office/core#115](https://github.com/Euro-Office/core/issues/115) — Path Traversal in ZIP Extraction (ZipSlip).

## Problem

The existing ZipSlip check in `do_extract_currentfile()` only rejected archive entries whose **normalized** path started with `../`. This left several bypass vectors:

| Payload | Old Check |
|---------|-----------|
| `../../../etc/passwd` | Caught |
| `foo/../../etc/passwd` | **Bypassed** — normalized to `../../etc/passwd` but the check only looked at the filename, not the full output path |
| `/etc/passwd` (Unix) | **Bypassed** — absolute paths were never rejected |
| `C:\Windows\... (Windows) | **Bypassed** — drive-letter absolute paths were never rejected |

## Fix

Replaced the weak check with proper **prefix-based containment validation**:

1. **Rejects empty normalized archive entry paths** — catches degenerate entries like `./` or `..`
2. **Rejects absolute paths in archive entries:**
   - Unix-like: `/etc/passwd` → rejected immediately
   - Windows: `C:\Windows\...` or `\\server\share\...` → rejected immediately
3. **Prefix containment check** — the core fix:
   - Normalizes both the output path and extraction directory via `ShortenPath()` to resolve all `../` and `./` components
   - Ensures the extraction directory ends with a separator for reliable prefix matching
   - Verifies `normalized_output_path` starts with `normalized_extract_dir/`
   - If not, returns `UNZ_INTERNALERROR`

## Attack vectors now blocked

| Payload | Old Check | New Check |
|---------|-----------|-----------|
| `../../../etc/passwd` | ✅ Caught | ✅ Caught |
| `foo/../../etc/passwd` | ❌ Bypassed | ✅ Caught |
| `/etc/passwd` (Unix) | ❌ Bypassed | ✅ Caught |
| `C:\Windows\... (Windows) | ❌ Bypassed | ✅ Caught |
| `\\server\share\...` (Windows) | ❌ Bypassed | ✅ Caught |

## Files changed

- `OfficeUtils/src/ZipUtilsCP.cpp` — replaced weak check with prefix-based containment validation in `do_extract_currentfile()`