### PR TITLE
refactor: add possibility to reduce memory load at linux builds

### DIFF
--- a/.docker/core-wasm.bake.Dockerfile
+++ b/.docker/core-wasm.bake.Dockerfile
@@ -12,6 +12,7 @@ FROM ghcr.io/euro-office/emsdk:5.0.4 AS core-wasm
     ARG BUILD_ROOT
     ARG CACHE_BUST
     ARG NUGET_SOURCE_PATH
+    ARG CMAKE_BUILD_PARALLEL_LEVEL=2
 
     ENV BUILD_ROOT=${BUILD_ROOT}
     ENV EM_CACHE=/em-cache
@@ -31,7 +32,7 @@ FROM ghcr.io/euro-office/emsdk:5.0.4 AS core-wasm
         emcmake cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                       -DEO_CORE_OUTPUT_DIR=/build-cache-wasm/dist /core
-        cmake --build . -- -j$(nproc)
+        cmake --build . --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}"
         ccache --show-stats
         echo "=== CCACHE ON DISK ==="
         du -sh /ccache || true

--- a/.docker/core.bake.Dockerfile
+++ b/.docker/core.bake.Dockerfile
@@ -147,6 +147,7 @@ FROM vcpkg-${NUGET_CACHE} AS core-base
 #### CORE ####
 FROM core-base AS core
     ARG NUGET_SOURCE_PATH
+    ARG CMAKE_BUILD_PARALLEL_LEVEL=2
     RUN --mount=type=cache,target=/build-cache \
         --mount=type=bind,source=${NUGET_SOURCE_PATH},target=/nuget-cache,rw \
         mkdir -p ${BUILD_ROOT} && \
@@ -161,5 +162,5 @@ FROM core-base AS core
         -DEO_CORE_OUTPUT_DIR=/build-cache/package/bin \
         -DEO_CORE_TOOLS_DIR=/build-cache/package/tools \
         /core && \
-        cmake --build . && \
+        cmake --build . --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}" && \
         cp -r package/* ${BUILD_ROOT}


### PR DESCRIPTION
## Description
The current Linux build path for core is too memory-aggressive for common developer hardware, especially notebooks with 16 GB RAM. On such systems, the build can consume nearly all available memory, trigger OOM conditions, or make the machine unresponsive.