### PR TITLE
Feature/configurable arch baseline

### DIFF
--- a/.docker/core.bake.Dockerfile
+++ b/.docker/core.bake.Dockerfile
@@ -9,6 +9,8 @@ ARG BUILD_ROOT
 ARG NUGET_SOURCE_PATH
 ARG PRODUCT=server
 ARG TARGETARCH
+ARG ARCH_TRIPLET=x64-linux-v2
+ARG ARCH_MARCH_FLAGS=-march=x86-64-v2
 
 # Desktop: 24.04 on arm, 22.04 on amd
 FROM ubuntu:22.04 AS vcpkg-base-desktop-amd64
@@ -147,6 +149,9 @@ FROM vcpkg-${NUGET_CACHE} AS core-base
 #### CORE ####
 FROM core-base AS core
     ARG NUGET_SOURCE_PATH
+    ARG TARGETARCH
+    ARG ARCH_TRIPLET
+    ARG ARCH_MARCH_FLAGS
     RUN --mount=type=cache,target=/build-cache \
         --mount=type=bind,source=${NUGET_SOURCE_PATH},target=/nuget-cache,rw \
         mkdir -p ${BUILD_ROOT} && \
@@ -154,10 +159,12 @@ FROM core-base AS core
         cmake -GNinja \
         -DVCPKG_MANIFEST_MODE=ON \
         -DVCPKG_MANIFEST_DIR=/core \
+        -DVCPKG_OVERLAY_TRIPLETS=/core/triplets \
+        -DVCPKG_TARGET_TRIPLET=${ARCH_TRIPLET} \
         -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_CXX_FLAGS_RELEASE="-O3 -w" \
-        -DCMAKE_C_FLAGS_RELEASE="-O3 -w" \
+        -DCMAKE_CXX_FLAGS_RELEASE="-O3 -w ${ARCH_MARCH_FLAGS}" \
+        -DCMAKE_C_FLAGS_RELEASE="-O3 -w ${ARCH_MARCH_FLAGS}" \
         -DEO_CORE_OUTPUT_DIR=/build-cache/package/bin \
         -DEO_CORE_TOOLS_DIR=/build-cache/package/tools \
         /core && \

--- a/triplets/x64-linux-baseline.cmake
+++ b/triplets/x64-linux-baseline.cmake
@@ -2,5 +2,7 @@ set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
 set(VCPKG_CXX_FLAGS "-march=x86-64")
 set(VCPKG_C_FLAGS "-march=x86-64")

--- a/triplets/x64-linux-baseline.cmake
+++ b/triplets/x64-linux-baseline.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_CXX_FLAGS "-march=x86-64")
+set(VCPKG_C_FLAGS "-march=x86-64")

--- a/triplets/x64-linux-v2.cmake
+++ b/triplets/x64-linux-v2.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_CXX_FLAGS "-march=x86-64-v2")
+set(VCPKG_C_FLAGS "-march=x86-64-v2")

--- a/triplets/x64-linux-v2.cmake
+++ b/triplets/x64-linux-v2.cmake
@@ -2,5 +2,7 @@ set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
 set(VCPKG_CXX_FLAGS "-march=x86-64-v2")
 set(VCPKG_C_FLAGS "-march=x86-64-v2")


### PR DESCRIPTION
## Summary

Makes the target x86-64 microarchitecture baseline for Linux builds configurable, instead of hardcoding it. Adds vcpkg overlay triplets (`x64-linux-v2` default, `x64-linux-baseline` for plain x86-64) and threads `ARCH_TRIPLET`/`ARCH_MARCH_FLAGS` through the Docker bake config and `build.sh`.

## Why

Raising the official baseline to x86-64-v2 (SSE4.2/POPCNT) gives Qt and other vcpkg-built dependencies access to SIMD-optimized code paths instead of falling back to unoptimized generic code — but it drops support for older CPUs that predate v2. Rather than the team maintaining a second, permanently-tracked toolchain to support that hardware, this exposes the microarchitecture as a build-time parameter so anyone who needs a legacy build can produce one themselves from the same sources, without affecting the default build path.

## Changes

- **`core`**: adds `triplets/x64-linux-v2.cmake` (default) and `triplets/x64-linux-baseline.cmake` vcpkg overlay triplets; wires `ARCH_TRIPLET`/`ARCH_MARCH_FLAGS` build args into the core cmake invocation in `.docker/core.bake.Dockerfile`.
- **`desktop-apps`**: same args threaded through `.docker/desktop-apps.bake.Dockerfile`'s vcpkg/cmake invocation, since Qt is built there via the vcpkg manifest.
- **Superproject**: declares `ARCH_TRIPLET` (default `x64-linux-v2`) and `ARCH_MARCH_FLAGS` (default `-march=x86-64-v2`) in `build/docker-bake.hcl` and `build/linux/docker-bake.hcl`, and exposes them as overridable environment variables in `build/linux/build.sh`.

## Usage

Default behavior is unchanged. To produce a baseline x86-64 build:

\`\`\`sh
ARCH_TRIPLET=x64-linux-baseline ARCH_MARCH_FLAGS=-march=x86-64 ./build.sh
\`\`\`

## Scope / non-goals

- No change to official release builds, CI, or support — those stay on x86-64-v2.
- Doesn't provide a one-flag "legacy build" experience end-to-end; someone building baseline still owns their own build/distribution.

https://github.com/Euro-Office/core/pull/125
https://github.com/Euro-Office/desktop-apps/pull/35
https://github.com/Euro-Office/DesktopEditors/pull/61