### PR TITLE
fix: DJVU RGBA channel order in WASM rendering

### DIFF
--- a/DjVuFile/DjVuFileImplementation.cpp
+++ b/DjVuFile/DjVuFileImplementation.cpp
@@ -719,7 +719,7 @@ unsigned char* CDjVuFileImplementation::ConvertToPixels(int nPageIndex, int nRas
 		GP<DjVuImage> pPage = m_pDoc->get_page(nPageIndex);
 		//pPage->wait_for_complete_decode();
 		pPage->set_rotate(0);
-		return ConvertToPixels(pPage, nRasterW, nRasterH, bIsFlip);
+		return ConvertToPixels(pPage, nRasterW, nRasterH, bIsFlip, true);
 	}
 	catch (...)
 	{
@@ -727,11 +727,11 @@ unsigned char* CDjVuFileImplementation::ConvertToPixels(int nPageIndex, int nRas
 	return NULL;
 }
 
-unsigned char* CDjVuFileImplementation::ConvertToPixels(GP<DjVuImage>& pPage, int nImageW, int nImageH, bool bFlip)
+unsigned char* CDjVuFileImplementation::ConvertToPixels(GP<DjVuImage>& pPage, int nImageW, int nImageH, bool bFlip, bool bIsSwapRGB)
 {
 	BYTE* pBufferDst = NULL;
 
-	auto processPixmap = [&](GP<GPixmap> pImage, bool bFlip = false)
+	auto processPixmap = [&](GP<GPixmap> pImage, bool bFlip = false, bool bIsSwapRGB = false)
 	{
 		pBufferDst = new BYTE[4 * nImageW * nImageH];
 
@@ -742,7 +742,10 @@ unsigned char* CDjVuFileImplementation::ConvertToPixels(GP<DjVuImage>& pPage, in
 			GPixel* pLine = pImage->operator[](nRow);
 			for (int i = 0; i < nImageW; ++i)
 			{
-				*pBuffer++ = 0xFF000000 | pLine->r << 16 | pLine->g << 8 | pLine->b;
+				if (bIsSwapRGB)
+					*pBuffer++ = 0xFF000000 | pLine->b << 16 | pLine->g << 8 | pLine->r;
+				else
+					*pBuffer++ = 0xFF000000 | pLine->r << 16 | pLine->g << 8 | pLine->b;
 				++pLine;
 			}
 		}
@@ -783,7 +786,7 @@ unsigned char* CDjVuFileImplementation::ConvertToPixels(GP<DjVuImage>& pPage, in
 	if (pPage->is_legal_photo() || pPage->is_legal_compound())
 	{
 		GP<GPixmap> pImage = pPage->get_pixmap(oRectAll, oRectAll);
-		processPixmap(pImage, bFlip);
+		processPixmap(pImage, bFlip, bIsSwapRGB);
 	}
 	else if (pPage->is_legal_bilevel())
 	{
@@ -795,7 +798,7 @@ unsigned char* CDjVuFileImplementation::ConvertToPixels(GP<DjVuImage>& pPage, in
 		GP<GPixmap> pImage = pPage->get_pixmap(oRectAll, oRectAll);
 		if (pImage)
 		{
-			processPixmap(pImage, bFlip);
+			processPixmap(pImage, bFlip, bIsSwapRGB);
 		}
 		else
 		{

--- a/DjVuFile/DjVuFileImplementation.h
+++ b/DjVuFile/DjVuFileImplementation.h
@@ -76,7 +76,7 @@ public:
 
 private:
 
-	unsigned char* ConvertToPixels(GP<DjVuImage>& pPage, int nRasterW, int nRasterH, bool bIsFlip = false);
+	unsigned char* ConvertToPixels(GP<DjVuImage>& pPage, int nRasterW, int nRasterH, bool bIsFlip = false, bool bIsSwapRGB = false);
 
 	void               CreateFrame(IRenderer* pRenderer, GP<DjVuImage>& pImage, int nPage, XmlUtils::CXmlNode& oText);
     void               CreatePdfFrame(IRenderer* pRenderer, GP<DjVuImage>& pImage, int nPage, XmlUtils::CXmlNode& oText);


### PR DESCRIPTION
## Summary

Fix the red and blue channel order when rendering DJVU pages into an RGBA pixel buffer for the web preview.

The packed pixel value previously produced BGRA byte order on little-endian systems, causing red elements to appear blue. This change adds an explicit RGB swap for the WASM rendering path while preserving the existing behavior for other callers.

## Visual verification

  ### Before

<img width="2194" height="1616" alt="image" src="https://github.com/user-attachments/assets/a652dd0a-dfaa-4e6c-b1b5-99f12fc5af75" />

  ### After


<img width="2194" height="1616" alt="image" src="https://github.com/user-attachments/assets/7fe5e248-bf90-4307-a1c5-744665316f2f" />


 ### Reproduction file
[djvu.zip](https://github.com/user-attachments/files/30255371/djvu.zip)
