### PR TITLE
fix(v8): pin depot_tools so gclient_paths.patch applies

### DIFF
--- a/Common/3dParty/v8/nc-build.py
+++ b/Common/3dParty/v8/nc-build.py
@@ -371,12 +371,21 @@ def fetch_and_patch():
         "Clone depot_tools"
     )
 
-    # Update depot_tools
+    # Pin depot_tools to a known-good revision instead of tracking HEAD.
+    # depot_tools main moves; commit f065bb3b0 (2026-07-13, "Add gclient getconfig
+    # subcommand") reworked gclient_paths.py so gclient_paths.patch no longer
+    # applies. 6e5a13d2 (2026-06-22) is the newest revision it applies against —
+    # pin it so the V8 build is reproducible and immune to depot_tools drift.
     nc.run_command(
-        [ "git", "pull", "origin", "main" ],
-        "Update depot_tools",
+        [ "git", "fetch", "--quiet", "origin" ],
+        "Fetch depot_tools",
         depot_tools_path,
         error_is_fatal = False
+    )
+    nc.run_command(
+        [ "git", "checkout", "--force", "--detach", "6e5a13d2598ee48c9c7afc750401533f30dde16e" ],
+        "Pin depot_tools to known-good revision",
+        depot_tools_path
     )
 
     # Fetch v8
@@ -431,6 +440,9 @@ solutions = [
     depot_env["GCLIENT_SUPPRESS_GIT_VERSION_WARNING"] = "1"
     depot_env["GYP_CHROMIUM_NO_ACTION"] = "1"
     depot_env["DEPOT_TOOLS_WIN_TOOLCHAIN"] = "0"
+    # Keep depot_tools from self-updating to HEAD during sync, which would undo
+    # the pin in fetch_and_patch() and re-break gclient_paths.patch.
+    depot_env["DEPOT_TOOLS_UPDATE"] = "0"
 
     if nc.is_windows():
         fake_pipes_shim_path = create_fake_pipes_shim()


### PR DESCRIPTION
nc-build.py cloned depot_tools then ran `git pull origin main`, tracking HEAD. gclient_paths.patch (drops four `@functools.lru_cache` decorators from gclient_paths.py) was authored against an older depot_tools; upstream f065bb3b0 (2026-07-13, "Add gclient getconfig subcommand") reworked gclient_paths.py, so the patch stopped applying and core failed to build on all arches.

Pin depot_tools to 6e5a13d2598ee48c9c7afc750401533f30dde16e (newest revision the patch applies against; verified with `git apply --check`) and set DEPOT_TOOLS_UPDATE=0 so it can't self-update back to HEAD during gclient sync. Verified: core builds and x2t links on linux/arm64.

Pinning stops the drift but doesn't advance depot_tools. To move it forward later, refresh gclient_paths.patch against the newer gclient_paths.py and bump the pin.

Fixes #124
Relates to #72 — this pins as the near-term unblock; the longer-term "do we still need v8 8.9 / these patches" decision stays there.

Unblocks the downstream builds that were failing on this:
- Euro-Office/DocumentServer#262
- Euro-Office/DocumentServer#143

Assisted-by: ClaudeCode:claude-opus-4-8