### PR TITLE
fix(v8): refresh gclient_paths.patch and pin depot_tools

### DIFF
--- a/Common/3dParty/v8/nc-build.py
+++ b/Common/3dParty/v8/nc-build.py
@@ -372,10 +372,15 @@ def fetch_and_patch():
     )
 
     # Pin depot_tools to a known-good revision instead of tracking HEAD.
-    # depot_tools main moves; commit f065bb3b0 (2026-07-13, "Add gclient getconfig
-    # subcommand") reworked gclient_paths.py so gclient_paths.patch no longer
-    # applies. 6e5a13d2 (2026-06-22) is the newest revision it applies against —
-    # pin it so the V8 build is reproducible and immune to depot_tools drift.
+    # depot_tools main moves and gclient_paths.patch is written against one specific
+    # revision of gclient_paths.py: f065bb3b0 (2026-07-13, "Add gclient getconfig
+    # subcommand") added a fifth @functools.lru_cache site, and 93974d014 (2026-07-21,
+    # ruff reformat) switched the file to double-quoted strings. Both invalidate the
+    # patch context. f394ab2c9 (2026-07-24) is the newest revision the current patch
+    # applies against, verified with `git apply --check`, and predates the depot_tools
+    # UV migration (db395c47f, 2026-08-02) which is not yet build-verified for V8 8.9.
+    # Keep this revision in sync with tools/8.9/*/nc-build.sh; when refreshing the
+    # patch, bump all three together.
     nc.run_command(
         [ "git", "fetch", "--quiet", "origin" ],
         "Fetch depot_tools",
@@ -383,7 +388,7 @@ def fetch_and_patch():
         error_is_fatal = False
     )
     nc.run_command(
-        [ "git", "checkout", "--force", "--detach", "6e5a13d2598ee48c9c7afc750401533f30dde16e" ],
+        [ "git", "checkout", "--force", "--detach", "f394ab2c993283e94680ca13db98b99927868e98" ],
         "Pin depot_tools to known-good revision",
         depot_tools_path
     )

--- a/Common/3dParty/v8/tools/8.9/arm64-linux-dynamic/gclient_paths.patch
+++ b/Common/3dParty/v8/tools/8.9/arm64-linux-dynamic/gclient_paths.patch
@@ -1,40 +1,48 @@
 diff --git a/gclient_paths.py b/gclient_paths.py
-index bd4d05b15..6cfe2118e 100644
+index 6d9d34360..e3fcc5a92 100644
 --- a/gclient_paths.py
 +++ b/gclient_paths.py
-@@ -20,7 +20,7 @@ import subprocess2
+@@ -21,7 +21,7 @@ import subprocess2
  # pylint: disable=line-too-long
- 
- 
+
+
 -@functools.lru_cache
 +
- def FindGclientRoot(from_dir, filename='.gclient'):
+ def FindGclientRoot(from_dir, filename=".gclient"):
      """Tries to find the gclient root."""
      real_from_dir = os.path.abspath(from_dir)
-@@ -73,7 +73,7 @@ def FindGclientRoot(from_dir, filename='.gclient'):
+@@ -76,7 +76,7 @@ def FindGclientRoot(from_dir, filename=".gclient"):
      return None
- 
- 
+
+
 -@functools.lru_cache
 +
  def _GetPrimarySolutionPathInternal(cwd):
      gclient_root = FindGclientRoot(cwd)
      if gclient_root:
-@@ -107,7 +107,7 @@ def GetPrimarySolutionPath(from_dir=None):
+@@ -112,7 +112,7 @@ def GetPrimarySolutionPath(from_dir=None):
      return _GetPrimarySolutionPathInternal(from_dir)
- 
- 
+
+
 -@functools.lru_cache
 +
  def _GetBuildtoolsPathInternal(cwd, override):
      if override is not None:
          return override
-@@ -162,7 +162,7 @@ def GetExeSuffix():
-     return ''
- 
- 
+@@ -174,7 +174,6 @@ def GetExeSuffix():
+     return ""
+
+
+-@functools.lru_cache
+ def _GetGClientConfigInner(gclient_root_dir_path, filename):
+     gclient_config_file = os.path.join(gclient_root_dir_path, filename)
+     if not os.path.exists(gclient_config_file):
+@@ -194,7 +193,7 @@ def GetGClientConfig(gclient_root_dir_path=None, filename=".gclient"):
+     return _GetGClientConfigInner(gclient_root_dir_path, filename)
+
+
 -@functools.lru_cache
 +
  def _GetGClientSolutions(gclient_root_dir_path):
-     gclient_config_file = os.path.join(gclient_root_dir_path, '.gclient')
-     gclient_config_contents = gclient_utils.FileRead(gclient_config_file)
+     config = GetGClientConfig(gclient_root_dir_path)
+     return config.get("solutions", []) if config else []

--- a/Common/3dParty/v8/tools/8.9/arm64-linux-dynamic/nc-build.sh
+++ b/Common/3dParty/v8/tools/8.9/arm64-linux-dynamic/nc-build.sh
@@ -61,6 +61,15 @@ export PATH="$DEPOT_TOOLS:$PATH"
 export VPYTHON_BYPASS="manually managed python not supported by chrome operations"
 export GCLIENT_SUPPRESS_GIT_VERSION_WARNING=1
 export GYP_CHROMIUM_NO_ACTION=1
+# Keep depot_tools from self-updating to HEAD during gclient sync, which would undo
+# the pin below.
+export DEPOT_TOOLS_UPDATE=0
+
+# Pin depot_tools to a known-good revision instead of tracking HEAD. gclient_paths.patch
+# only applies against this revision's gclient_paths.py; upstream periodically reworks
+# and reformats that file (f065bb3b0 2026-07-13, 93974d014 2026-07-21), which silently
+# breaks the patch. Keep in sync with Common/3dParty/v8/nc-build.py.
+DEPOT_TOOLS_REV="f394ab2c993283e94680ca13db98b99927868e98"
 
 if [ ! -d "$DEPOT_TOOLS" ]; then
   log "Cloning depot_tools..."
@@ -68,9 +77,11 @@ if [ ! -d "$DEPOT_TOOLS" ]; then
     || abort_op "clone depot_tools failed"
 fi
 
-# Update depot_tools
+# Pin depot_tools to the known-good revision (see DEPOT_TOOLS_REV above)
 cd "$DEPOT_TOOLS"
-git pull origin main || log "depot_tools update failed (non-fatal)"
+git fetch --quiet origin || log "depot_tools fetch failed (non-fatal)"
+git checkout --force --detach "$DEPOT_TOOLS_REV" \
+  || abort_op "checkout of depot_tools $DEPOT_TOOLS_REV failed"
 cd "$work_dir"
 
 # ---------- fetch V8 ----------

--- a/Common/3dParty/v8/tools/8.9/x64-linux-dynamic/gclient_paths.patch
+++ b/Common/3dParty/v8/tools/8.9/x64-linux-dynamic/gclient_paths.patch
@@ -1,40 +1,48 @@
 diff --git a/gclient_paths.py b/gclient_paths.py
-index bd4d05b15..6cfe2118e 100644
+index 6d9d34360..e3fcc5a92 100644
 --- a/gclient_paths.py
 +++ b/gclient_paths.py
-@@ -20,7 +20,7 @@ import subprocess2
+@@ -21,7 +21,7 @@ import subprocess2
  # pylint: disable=line-too-long
- 
- 
+
+
 -@functools.lru_cache
 +
- def FindGclientRoot(from_dir, filename='.gclient'):
+ def FindGclientRoot(from_dir, filename=".gclient"):
      """Tries to find the gclient root."""
      real_from_dir = os.path.abspath(from_dir)
-@@ -73,7 +73,7 @@ def FindGclientRoot(from_dir, filename='.gclient'):
+@@ -76,7 +76,7 @@ def FindGclientRoot(from_dir, filename=".gclient"):
      return None
- 
- 
+
+
 -@functools.lru_cache
 +
  def _GetPrimarySolutionPathInternal(cwd):
      gclient_root = FindGclientRoot(cwd)
      if gclient_root:
-@@ -107,7 +107,7 @@ def GetPrimarySolutionPath(from_dir=None):
+@@ -112,7 +112,7 @@ def GetPrimarySolutionPath(from_dir=None):
      return _GetPrimarySolutionPathInternal(from_dir)
- 
- 
+
+
 -@functools.lru_cache
 +
  def _GetBuildtoolsPathInternal(cwd, override):
      if override is not None:
          return override
-@@ -162,7 +162,7 @@ def GetExeSuffix():
-     return ''
- 
- 
+@@ -174,7 +174,6 @@ def GetExeSuffix():
+     return ""
+
+
+-@functools.lru_cache
+ def _GetGClientConfigInner(gclient_root_dir_path, filename):
+     gclient_config_file = os.path.join(gclient_root_dir_path, filename)
+     if not os.path.exists(gclient_config_file):
+@@ -194,7 +193,7 @@ def GetGClientConfig(gclient_root_dir_path=None, filename=".gclient"):
+     return _GetGClientConfigInner(gclient_root_dir_path, filename)
+
+
 -@functools.lru_cache
 +
  def _GetGClientSolutions(gclient_root_dir_path):
-     gclient_config_file = os.path.join(gclient_root_dir_path, '.gclient')
-     gclient_config_contents = gclient_utils.FileRead(gclient_config_file)
+     config = GetGClientConfig(gclient_root_dir_path)
+     return config.get("solutions", []) if config else []

--- a/Common/3dParty/v8/tools/8.9/x64-linux-dynamic/nc-build.sh
+++ b/Common/3dParty/v8/tools/8.9/x64-linux-dynamic/nc-build.sh
@@ -71,6 +71,15 @@ export PATH="$DEPOT_TOOLS:$PATH"
 export VPYTHON_BYPASS="manually managed python not supported by chrome operations"
 export GCLIENT_SUPPRESS_GIT_VERSION_WARNING=1
 export GYP_CHROMIUM_NO_ACTION=1
+# Keep depot_tools from self-updating to HEAD during gclient sync, which would undo
+# the pin below.
+export DEPOT_TOOLS_UPDATE=0
+
+# Pin depot_tools to a known-good revision instead of tracking HEAD. gclient_paths.patch
+# only applies against this revision's gclient_paths.py; upstream periodically reworks
+# and reformats that file (f065bb3b0 2026-07-13, 93974d014 2026-07-21), which silently
+# breaks the patch. Keep in sync with Common/3dParty/v8/nc-build.py.
+DEPOT_TOOLS_REV="f394ab2c993283e94680ca13db98b99927868e98"
 
 if [ ! -d "$DEPOT_TOOLS" ]; then
   log "Cloning depot_tools..."
@@ -78,9 +87,11 @@ if [ ! -d "$DEPOT_TOOLS" ]; then
     || abort_op "clone depot_tools failed"
 fi
 
-# Update depot_tools
+# Pin depot_tools to the known-good revision (see DEPOT_TOOLS_REV above)
 cd "$DEPOT_TOOLS"
-git pull origin main || log "depot_tools update failed (non-fatal)"
+git fetch --quiet origin || log "depot_tools fetch failed (non-fatal)"
+git checkout --force --detach "$DEPOT_TOOLS_REV" \
+  || abort_op "checkout of depot_tools $DEPOT_TOOLS_REV failed"
 cd "$work_dir"
 
 # ---------- fetch V8 ----------


### PR DESCRIPTION
`gclient_paths.patch` drops the `@functools.lru_cache` decorators from
depot_tools' `gclient_paths.py`. Two upstream changes invalidated its context:
`f065bb3b0` (2026-07-13) added a fifth decorated function,
`_GetGClientConfigInner`, and `93974d014` (2026-07-21, ruff reformat) switched
the file to double-quoted strings.

#127 worked around this by pinning depot_tools to `6e5a13d2`, the last revision
the old four-hunk patch applied against — but it only pinned
`Common/3dParty/v8/nc-build.py`. The two Docker binary builders,
`tools/8.9/{x64,arm64}-linux-dynamic/nc-build.sh`, kept running
`git pull origin main` and have been broken since `f065bb3b0` as well.

This PR does both halves:
- takes the regenerated five-hunk patch from #129 (both arch dirs);
- moves all three build paths onto one pinned revision, `f394ab2c9`
  (2026-07-24) — the newest revision the new patch applies against
  (range `93974d014..HEAD`), and the last before the depot_tools UV migration
  `db395c47f`, which isn't build-verified against V8 8.9;
- exports `DEPOT_TOOLS_UPDATE=0` in the shell builders so `gclient sync`
  can't self-update back to HEAD.

Verified locally: `git apply --check` passes for both arch dirs at the new pin,
and a full `docker buildx bake core` with v8 cleared from the build cache builds
v8 from source and links `x2t`.

Note for reviewers: a green CI run here does not by itself prove the v8 source
build works. With `NEXTCLOUD_USER`/`NEXTCLOUD_PASS` available, `ensure_dep()`
downloads a prebuilt v8 and skips `nc-build.py` entirely — which is why #129's
failure only surfaced on a fork PR without those secrets.

Supersedes #129. Follow-up to #127; the longer-term "do we still need v8 8.9 and
these patches" question stays in #72.

Patch authored by @pplupo in #129, originally worked out by @Duckle29 in
Euro-Office/DesktopEditors#66 — both credited via `Co-authored-by`.

Euro-Office/DesktopEditors#66 itself needs a `core` submodule bump in
DesktopEditors, which I'll open separately.


Assisted-by: ClaudeCode:claude-opus-5