### PR TITLE
fix(common): list symlinked files when scanning directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
         add_subdirectory( "${CORE_ROOT_DIR}/OfficeUtils/tests" officeutils_test )
         add_subdirectory( "${CORE_ROOT_DIR}/OdfFile/Reader/Converter/SMCustomShape2OOXML/TestSMCustomShape" starmath_smcustomshape_test )
         add_subdirectory( "${CORE_ROOT_DIR}/OdfFile/Test/test_odf" test_odf )
+        add_subdirectory( "${CORE_ROOT_DIR}/DesktopEditor/common/test" directory_test )
     endif()
 
 endif()

--- a/DesktopEditor/common/Directory.cpp
+++ b/DesktopEditor/common/Directory.cpp
@@ -143,6 +143,22 @@ namespace NSDirectory
 					else if (S_ISDIR(buff.st_mode))
 						nType = 1;
 				}
+				else if (DT_LNK == dirp->d_type)
+				{
+					// #128: symlinked entries are reported as DT_LNK and were dropped
+					// entirely, so fonts installed as symlinks were never picked up.
+					// stat() follows the link, so the target decides.
+					//
+					// Only regular-file targets are accepted. A symlinked directory is
+					// left unclassified on purpose: the recursive walk would descend
+					// through the link, and DeleteDirectory() (built on GetFiles() and
+					// GetDirectories()) would remove the link target's contents rather
+					// than the link itself.
+					struct stat buff;
+					std::string sTmp = std::string((char*)pUtf8) + "/" + std::string(dirp->d_name);
+					if (0 == stat(sTmp.c_str(), &buff) && S_ISREG(buff.st_mode))
+						nType = 2;
+				}
 
 				if (2 == nType)
 				{

--- a/DesktopEditor/common/test/CMakeLists.txt
+++ b/DesktopEditor/common/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(directory_test)
+
+set(CORE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
+
+include(${CORE_ROOT_DIR}/common.cmake)
+
+# NSDirectory and NSFile are part of kernel.
+if(NOT TARGET kernel)
+    add_subdirectory(${CORE_ROOT_DIR}/Common kernel)
+endif()
+
+add_core_gtest(
+    NAME    directory_test
+    SOURCES main.cpp
+    LIBS    kernel
+    GTEST_MAIN
+)

--- a/DesktopEditor/common/test/main.cpp
+++ b/DesktopEditor/common/test/main.cpp
@@ -1,0 +1,148 @@
+#include "gtest/gtest.h"
+
+#include "../Directory.h"
+#include "../File.h"
+
+#include <algorithm>
+#include <cstdio>
+#ifndef _WIN32
+#include <ftw.h>
+#include <unistd.h>
+#endif
+
+// Builds a scratch tree next to the test binary. Nothing is committed to the
+// repository: SetUp() creates
+//
+//   <root>/real.bin          regular file
+//   <root>/sub/nested.bin    regular file
+//
+// and each test adds on top of that the symlink it needs.
+//
+class CDirectoryTest : public testing::Test
+{
+protected:
+	std::wstring m_root;
+
+	static bool Symlink(const std::string& sTarget, const std::wstring& wsLink)
+	{
+#ifdef _WIN32
+		return false;
+#else
+		return 0 == symlink(sTarget.c_str(), U_TO_UTF8(wsLink).c_str());
+#endif
+	}
+
+#ifndef _WIN32
+	static int RemoveEntry(const char* pPath, const struct stat*, int, struct FTW*)
+	{
+		return remove(pPath);
+	}
+#endif
+
+	// Cleanup deliberately does not go through NSDirectory: DeleteDirectory()
+	// enumerates with GetFiles()/GetDirectories(), the very functions under test.
+	// They drop symlinks today, so the tree would survive and leak state between
+	// tests — which silently turned every case into a skip on the second run.
+	void RemoveTree()
+	{
+#ifdef _WIN32
+		NSDirectory::DeleteDirectory(m_root);
+#else
+		nftw(U_TO_UTF8(m_root).c_str(), RemoveEntry, 16, FTW_DEPTH | FTW_PHYS);
+#endif
+	}
+
+	static bool Contains(const std::vector<std::wstring>& oArray, const std::wstring& wsName)
+	{
+		return std::any_of(oArray.begin(), oArray.end(),
+			[&wsName](const std::wstring& ws) { return ws.size() >= wsName.size() &&
+				0 == ws.compare(ws.size() - wsName.size(), wsName.size(), wsName); });
+	}
+
+	void SetUp() override
+	{
+		m_root = NSFile::GetProcessDirectory() + L"/directory_test_tree";
+		RemoveTree();
+		ASSERT_TRUE(NSDirectory::CreateDirectory(m_root));
+
+		ASSERT_TRUE(NSFile::CFileBinary::SaveToFile(m_root + L"/real.bin", L"x"));
+		ASSERT_TRUE(NSDirectory::CreateDirectory(m_root + L"/sub"));
+		ASSERT_TRUE(NSFile::CFileBinary::SaveToFile(m_root + L"/sub/nested.bin", L"x"));
+	}
+
+	void TearDown() override
+	{
+		RemoveTree();
+	}
+};
+
+// --- #128: entries that readdir reports as DT_LNK were dropped ---
+
+TEST_F(CDirectoryTest, symlinked_file_is_listed)
+{
+	if (!Symlink("real.bin", m_root + L"/link.bin"))
+		GTEST_SKIP() << "symlinks unavailable on this platform";
+
+	std::vector<std::wstring> oFiles = NSDirectory::GetFiles(m_root, false);
+
+	EXPECT_TRUE(Contains(oFiles, L"real.bin"));
+	EXPECT_TRUE(Contains(oFiles, L"link.bin"));
+}
+
+// Symlinked directories stay out on purpose. GetDirectories() feeds
+// DeleteDirectory(), which recurses over its result: reporting a symlinked
+// directory there would make DeleteDirectory() delete the link target's contents
+// instead of just removing the link. This test pins that decision — if it ever
+// fails, read the comment in Directory.cpp before "fixing" it.
+TEST_F(CDirectoryTest, symlinked_directory_is_not_listed)
+{
+	if (!Symlink("sub", m_root + L"/sublink"))
+		GTEST_SKIP() << "symlinks unavailable on this platform";
+
+	std::vector<std::wstring> oDirs = NSDirectory::GetDirectories(m_root);
+
+	EXPECT_TRUE(Contains(oDirs, L"sub"));
+	EXPECT_FALSE(Contains(oDirs, L"sublink"));
+}
+
+// --- guards on the new behaviour (these pass before the fix as well) ---
+
+// A symlinked directory passed in directly is scanned normally: opendir()
+// follows the link. Only symlinked *subdirectories* discovered during recursion
+// are skipped — so the common layout, a font directory that is itself a symlink,
+// keeps working.
+TEST_F(CDirectoryTest, symlinked_root_directory_is_scanned)
+{
+	if (!Symlink("sub", m_root + L"/sublink"))
+		GTEST_SKIP() << "symlinks unavailable on this platform";
+
+	std::vector<std::wstring> oFiles = NSDirectory::GetFiles(m_root + L"/sublink", false);
+
+	EXPECT_TRUE(Contains(oFiles, L"nested.bin"));
+}
+
+TEST_F(CDirectoryTest, dangling_symlink_is_skipped)
+{
+	if (!Symlink("missing.bin", m_root + L"/broken.bin"))
+		GTEST_SKIP() << "symlinks unavailable on this platform";
+
+	std::vector<std::wstring> oFiles = NSDirectory::GetFiles(m_root, false);
+
+	EXPECT_TRUE(Contains(oFiles, L"real.bin"));
+	EXPECT_FALSE(Contains(oFiles, L"broken.bin"));
+}
+
+TEST_F(CDirectoryTest, self_referencing_symlink_does_not_recurse_forever)
+{
+	if (!Symlink(".", m_root + L"/loop"))
+		GTEST_SKIP() << "symlinks unavailable on this platform";
+
+	std::vector<std::wstring> oFiles = NSDirectory::GetFiles(m_root, true);
+
+	// The loop is never entered because a symlinked directory is not classified
+	// as a directory, so the recursive walk has nothing to descend into. If that
+	// ever changes, this scan would descend root/loop/loop/... until the path
+	// exceeds PATH_MAX, reporting real.bin once per level — hence the bound.
+	EXPECT_TRUE(Contains(oFiles, L"real.bin"));
+	EXPECT_LT(oFiles.size(), (size_t)10);
+}


### PR DESCRIPTION
> **Note for the author:** this description is a factual scaffold — please replace it with your own wording before marking the PR ready for review.

Part of #128.

## What was wrong

`readdir()` reports a symlink as `DT_LNK`. The POSIX listing loop in `NSDirectory::GetFiles2()` (`DesktopEditor/common/Directory.cpp`) classified only `DT_REG`, `DT_DIR` and `DT_UNKNOWN`, so `DT_LNK` entries fell through unclassified and were dropped. Fonts installed as symlinks were therefore never picked up.

## The change

`DT_LNK` now goes through `stat()`, which follows the link, so the target decides. Only regular-file targets are listed.

## What this deliberately does not do

Symlinked **directories** are still not reported. `DeleteDirectory()` is built on `GetFiles()`/`GetDirectories()` and recurses over what they return — reporting a symlinked directory there would make it delete the **link target's** contents instead of just removing the link. That is a data-loss regression, so the limitation is intentional and pinned by a test (`symlinked_directory_is_not_listed`), with the reasoning in a comment next to the fix.

This is narrower than it sounds: a directory symlink passed to `GetFiles()` **directly** is scanned normally, because `opendir()` follows it. Only symlinked *subdirectories* discovered during recursion are skipped. There is a test for that too.

So #128 stays open for the symlinked-subdirectory half.

## Tests

Adds `DesktopEditor/common/test`, a new GoogleTest suite registered with CTest — the first unit test for `DesktopEditor/common`. It builds its tree at run time (regular file, symlink to it, dangling symlink, self-referencing symlink), so **no fixtures are committed**.

Five cases: the fix itself, the deliberate limitation, the symlinked-root case, a dangling symlink, and a self-referencing symlink that would blow up if a future change started following directory symlinks.

## Verification

Red/green was verified in both directions — the fix was removed and restored:

```console
$ # with the fix reverted
$ ctest --test-dir build -R directory_test -V
[  FAILED  ] CDirectoryTest.symlinked_file_is_listed
[       OK ] CDirectoryTest.symlinked_directory_is_not_listed
[       OK ] CDirectoryTest.symlinked_root_directory_is_scanned
[       OK ] CDirectoryTest.dangling_symlink_is_skipped
[       OK ] CDirectoryTest.self_referencing_symlink_does_not_recurse_forever
[  PASSED  ] 4 tests.

$ # with the fix in place
$ ctest --test-dir build -R directory_test -V
[  PASSED  ] 5 tests.
```

Repeated three times with identical results, and the other built CTest suites still pass (6/6). Built on Fedora with `-DEO_BUILD_TESTS=ON`.

Two things I checked before proposing this, in case they come up in review:

- `NSFile::CFileBinary::Remove()` uses `std::remove()`, which unlinks the **link**, not the target — so `DeleteDirectory()` now also cleans up symlinked files instead of leaving them behind.
- `CFontList::Add()` deduplicates by font name + bold + italic, so a symlink sitting next to its target does not produce a duplicate font entry.

## Known, not addressed here

- The `MAC`/`_IOS` variants of these loops have the same gap and additionally lack the `DT_UNKNOWN` fallback.
- `CopyDirectory()` likewise skips symlinked files.

Neither is testable on this machine, so I left both alone rather than shipping unverified code.

## AI assistance

Prepared with AI assistance (Claude Code, `claude-opus-5`); the commit carries an `Assisted-by:` trailer.
