### PR TITLE
fix(common): resolve a trailing ".." in NSSystemPath::ShortenPath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
         add_subdirectory( "${CORE_ROOT_DIR}/OfficeUtils/tests" officeutils_test )
         add_subdirectory( "${CORE_ROOT_DIR}/OdfFile/Reader/Converter/SMCustomShape2OOXML/TestSMCustomShape" starmath_smcustomshape_test )
         add_subdirectory( "${CORE_ROOT_DIR}/OdfFile/Test/test_odf" test_odf )
+        add_subdirectory( "${CORE_ROOT_DIR}/DesktopEditor/common/test" path_test )
     endif()
 
 endif()

--- a/DesktopEditor/common/Path.cpp
+++ b/DesktopEditor/common/Path.cpp
@@ -213,7 +213,7 @@ namespace NSSystemPath
 
 		if (L".." == wsToken)
 		{
-			if (!arStack.empty() && L".." == arStack.top())
+			if (!arStack.empty() && L".." != arStack.top())
 				arStack.pop();
 			else
 				arStack.push(wsToken);
@@ -236,6 +236,12 @@ namespace NSSystemPath
 			wsNewPath = arStack.top() + L'/' + wsNewPath;
 			arStack.pop();
 		}
+
+		// wsNewPath stays empty when the loop above breaks on the first entry
+		// (bRemoveExternalPath with a leading ".."), and pop_back() on an empty
+		// string is undefined behaviour.
+		if (wsNewPath.empty())
+			return std::wstring();
 
 		wsNewPath.pop_back();
 

--- a/DesktopEditor/common/test/CMakeLists.txt
+++ b/DesktopEditor/common/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(path_test)
+
+set(CORE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../..")
+
+include(${CORE_ROOT_DIR}/common.cmake)
+
+# NSSystemPath is part of kernel.
+if(NOT TARGET kernel)
+    add_subdirectory(${CORE_ROOT_DIR}/Common kernel)
+endif()
+
+add_core_gtest(
+    NAME    path_test
+    SOURCES path.cpp
+    LIBS    kernel
+    GTEST_MAIN
+)

--- a/DesktopEditor/common/test/path.cpp
+++ b/DesktopEditor/common/test/path.cpp
@@ -1,0 +1,77 @@
+#include "gtest/gtest.h"
+
+#include "../Path.h"
+
+// ShortenPath resolves "." and ".." lexically, without touching the filesystem.
+// Its result is used as a containment check by every one of its callers: the
+// ZipSlip guard in OfficeUtils/src/ZipUtilsCP.cpp, the "../" rejection in
+// EpubFile/src/CEpubFile.cpp, and several starts_with(root) checks in HtmlFile2,
+// OFDFile and the SVG image loader. It therefore decides whether a path taken
+// from a document is accepted, which is why it is worth pinning precisely.
+
+TEST(ShortenPath, keeps_a_plain_relative_path)
+{
+	EXPECT_EQ(L"a/b/c", NSSystemPath::ShortenPath(L"a/b/c"));
+}
+
+TEST(ShortenPath, resolves_a_parent_reference_in_the_middle)
+{
+	EXPECT_EQ(L"b", NSSystemPath::ShortenPath(L"a/../b"));
+}
+
+// --- defects reproduced below ---
+
+TEST(ShortenPath, resolves_a_trailing_parent_reference)
+{
+	EXPECT_EQ(L"", NSSystemPath::ShortenPath(L"a/.."));
+}
+
+TEST(ShortenPath, keeps_consecutive_parent_references)
+{
+	EXPECT_EQ(L"../..", NSSystemPath::ShortenPath(L"../.."));
+}
+
+TEST(ShortenPath, does_not_crash_on_bare_parent_when_removing_external_path)
+{
+	EXPECT_EQ(L"", NSSystemPath::ShortenPath(L"..", true));
+}
+
+// --- guards: behaviour that must not change (these pass before the fix too) ---
+
+TEST(ShortenPath, keeps_a_leading_parent_chain)
+{
+	EXPECT_EQ(L"../../etc/passwd", NSSystemPath::ShortenPath(L"../../etc/passwd"));
+}
+
+TEST(ShortenPath, keeps_an_absolute_path)
+{
+	EXPECT_EQ(L"/tmp/evil.txt", NSSystemPath::ShortenPath(L"/tmp/evil.txt"));
+}
+
+TEST(ShortenPath, returns_empty_for_empty_input)
+{
+	EXPECT_EQ(L"", NSSystemPath::ShortenPath(L""));
+}
+
+TEST(ShortenPath, drops_current_directory_segments)
+{
+	EXPECT_EQ(L"a/b", NSSystemPath::ShortenPath(L"./a/./b"));
+}
+
+// Archive entries and HTML sources routinely use backslashes; the callers rely on
+// them being treated as separators rather than as part of a name.
+TEST(ShortenPath, treats_a_backslash_as_a_separator)
+{
+	EXPECT_EQ(L"b", NSSystemPath::ShortenPath(L"a\\..\\b"));
+}
+
+TEST(ShortenPath, collapses_repeated_and_trailing_separators)
+{
+	EXPECT_EQ(L"a/b", NSSystemPath::ShortenPath(L"a//b"));
+	EXPECT_EQ(L"a/b", NSSystemPath::ShortenPath(L"a/b/"));
+}
+
+TEST(ShortenPath, drops_the_external_prefix_when_asked)
+{
+	EXPECT_EQ(L"a", NSSystemPath::ShortenPath(L"../a", true));
+}


### PR DESCRIPTION
# #137 — path normalization

Own find, not from a report.

## Bug

`NSSystemPath::ShortenPath` handles a trailing `..` in a post-loop branch that
had the operator inverted (`==` where the in-loop branch uses `!=`), so the two
cases were swapped:

| top of stack | correct | actual | symptom |
| --- | --- | --- | --- |
| normal segment | pop | pushed | `a/..` unresolved |
| `..` | push | popped | `../..` → `""` |

Only paths without a trailing separator reach that branch — hence `a/../` worked
and `a/..` didn't.

Same function: `pop_back()` on an empty string when the assembly loop breaks on
the first entry. UB, segfault in practice.

## Impact

All 8 callers use the result as a containment check on document-supplied paths
(ZipSlip guard in `ZipUtilsCP.cpp:294`, `../` rejection in `CEpubFile.cpp:165`,
`starts_with(root)` in HtmlFile2 ×2, OOXMLTags ×2, OFDFile, CImage). An empty
result passes a "starts with `../`" test.

Measured over `Combine(root, rel)`, exactly one verdict flips: `..` gave
`/data/..`, which passed `starts_with("/data")` textually while pointing one
level above. Now rejected. Five other cases unchanged.

## Change

`DesktopEditor/common/Path.cpp`, +7/−1 — one operator on line 216, one guard
before `pop_back()`.

## Tests

New `DesktopEditor/common/test`, first unit tests for this module. 12 cases:
3 reproduce the defects, 9 pin behaviour that must not change. Verified both
ways (fix reverted → 2 failures plus a SEGFAULT in
`does_not_crash_on_bare_parent_when_removing_external_path`; fix in place →
12/12), 3 identical runs. Other CTest suites still pass 6/6, including
`officeutils_test`, which extracts archives through `ShortenPath`.

## Notes

- `ShortenPath(L"/")` returns `""` rather than `/`. Looks wrong, out of scope,
  deliberately not pinned.
- EpubFile / HtmlFile2 / OFDFile have no tests — reasoning there rests on
  reading the code plus the measurement, not an executed suite.
- Adds `DesktopEditor/common/test/`, same directory as #136. Whichever lands
  second needs the two `CMakeLists.txt` merged by hand.

## AI assistance

Prepared with AI assistance (Claude Code, `claude-opus-5`); commit carries an
`Assisted-by:` trailer.